### PR TITLE
Qcoupling: fixed x2

### DIFF
--- a/pyEPR/core.py
+++ b/pyEPR/core.py
@@ -592,7 +592,7 @@ class pyEPR_HFSS(object):
             I_peak = self.calc_avg_current_J_surf_mag(variation, port['rect'],
                                                       port['length'])
             U_dissip = 0.5 * port['R'] * I_peak**2 * 1 / freq
-            p = U_dissip / U_E
+            p = U_dissip / (U_E/2) # U_E is 2x the peak electrical energy
             kappa = p * freq
             Q = 2 * np.pi * freq / kappa
             Qp['Q_' + port_nm] = Q


### PR DESCRIPTION
Fixed a factor of 2. U_E, as defined in the code is 2x the peak energy. After the fix, I have quantitative agreement between the Q HFSS gives, and the Q coupling calculated with this code. This is for qubit + resonator system who's only loss is through a single port. I get Qhfss = 7.138332e+03 and Qpyepr=7.387072e+03. So I think we are good now.