### PR TITLE
Fixed Tutorial 1

### DIFF
--- a/_tutorial_notebooks/Tutorial 1.  Startup example.ipynb
+++ b/_tutorial_notebooks/Tutorial 1.  Startup example.ipynb
@@ -859,7 +859,7 @@
    "source": [
     "import pandas as pd\n",
     "for variation in eprh.variations[:2]: # just for the first 2\n",
-    "    Fs, Qs = eprh.get_freqs_bare_pd(variation=variation)\n",
+    "    Fs, Qs = eprh.get_freqs_bare_pd(variation=variation, frame=False)\n",
     "    display(pd.DataFrame({'Freq. (GHz)':Fs, 'Quality Factor':Qs}))"
    ]
   },
@@ -2239,7 +2239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The [tutorial](https://github.com/zlatko-minev/pyEPR/blob/master/_tutorial_notebooks/Tutorial%201.%20%20Startup%20example.ipynb) was created for an older version of the code and did not run `In[17]` with the current version.

The function `DistributedAnalysis.get_freqs_bare_pd()` added an option to either return a pandas dataframe or a pandas series with the `frame` option. The tutorial was created at a time when the function only returned a pandas series. There are other (probably better) ways to fix this issue but I chose the one that changes the least.