### PR TITLE
Added _maximum and maximum_vol functions to the CalcObj class

### DIFF
--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -2687,6 +2687,10 @@ class CalcObject(COMWrapper):
         stack = self.stack + [(type, name), ("CalcOp", "Integrate")]
         return CalcObject(stack, self.setup)
 
+    def _maximum(self, name, type):
+        stack = self.stack + [(type, name), ("CalcOp", "Maximum")]
+        return CalcObject(stack, self.setup)
+
     def getQty(self, name):
         stack = self.stack + [("EnterQty", name)]
         return CalcObject(stack, self.setup)
@@ -2717,6 +2721,9 @@ class CalcObject(COMWrapper):
 
     def integrate_vol(self, name="AllObjects"):
         return self._integrate(name, "EnterVol")
+
+    def maximum_vol(self, name='AllObjects'):
+        return self._maximum(name, 'EnterVol')
 
     def times_eps(self):
         stack = self.stack + [("ClcMaterial", ("Permittivity (epsi)", "mult"))]


### PR DESCRIPTION
This was actually created by Serge. It was used to calculate the mode volume. Not sure if this would be useful to other people.

Might be useful to add more Ansys functionality to `ansys.py` to be easily accessed with the pyEPR package, without needing to change it.