### PR TITLE
Update installation information in documentation to include conda and pypi, close #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Welcome to pyEPR :beers:!
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/zlatko-minev/pyEPR)
 [![star this repo](http://githubbadges.com/star.svg?user=zlatko-minev&repo=pyEPR&style=flat)](https://github.com/zlatko-minev/pyEPR)
 [![fork this repo](http://githubbadges.com/fork.svg?user=zlatko-minev&repo=pyEPR&style=flat)](https://github.com/zlatko-minev/pyEPR/fork)
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/pyepr-quantum/badges/installer/conda.svg)](https://conda.anaconda.org/conda-forge)
 
 <br>
 
-## :bangbang: :bangbang: pyEPR Working group meeting -- Planning for the future of pyEPR 
+## :bangbang: :bangbang: pyEPR Working group meeting -- Planning for the future of pyEPR
 
 * Please sign-up here: https://github.com/zlatko-minev/pyEPR/issues/45 or [directly here](https://docs.google.com/forms/d/e/1FAIpQLScd3WyfzDS47D0WB9skkSPQAXCnKLf7JMxsZ7BnMwK0LjE3Sw/viewform?usp=sf_link) :bangbang: :beers:
 
@@ -38,20 +39,20 @@ Warning: pyEPR organization was significnatly improved in v0.8-dev (starting 202
 * Britton [Plourde Lab](https://bplourde.expressions.syr.edu/), Syracuse University, USA
 * Javad [Shabani Lab](https://wp.nyu.edu/shabanilab/) Quantum Materials & Devices, NYU, NY, USA
 * UChicago Dave Schuster Lab, USA
-* SQC lab - Shay Hacohen Gourgy, Israel 
+* SQC lab - Shay Hacohen Gourgy, Israel
 * Lawrence Berkeley National Lab
 * Colorado School of Mines, USA
 * Syracuse University, USA
 * IPQC, SJTU, Shanghai, China
 * Bhabha Atomic Research Centre, India
 * Quantum Computing UK
-* Alice&Bob, France 
+* Alice&Bob, France
 * ... and many more! (Please e-mail `zlatko.minev@aya.yale.edu` with updates.)
 
 
 ## How do I cite `pyEPR` when I publish?
 Cite the following and/or e-mail [`zlatko.minev@aya.yale.edu`](https://www.zlatko-minev.com/) or [`zaki leghtas`](http://cas.ensmp.fr/~leghtas/)
-* [arXiv:1902.10355](https://arxiv.org/abs/1902.10355) Z.K. Minev, Ph.D. Dissertation, Yale University (2018), Chapter 4. 
+* [arXiv:1902.10355](https://arxiv.org/abs/1902.10355) Z.K. Minev, Ph.D. Dissertation, Yale University (2018), Chapter 4.
 * Z.K. Minev, Z. Leghtas, _et al._ (to appear soon on arXiv) (2020)
 
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Welcome to pyEPR :beers:!
 [![star this repo](http://githubbadges.com/star.svg?user=zlatko-minev&repo=pyEPR&style=flat)](https://github.com/zlatko-minev/pyEPR)
 [![fork this repo](http://githubbadges.com/fork.svg?user=zlatko-minev&repo=pyEPR&style=flat)](https://github.com/zlatko-minev/pyEPR/fork)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pyepr-quantum/badges/installer/conda.svg)](https://conda.anaconda.org/conda-forge)
+[![PyPI version](https://badge.fury.io/py/pyEPR-quantum.svg)](https://badge.fury.io/py/pyEPR-quantum)
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Use `pyEPR` directly from the source, and pull updates from the master git repo,
 Please keep up to date with `pyEPR` by using git. We like to make it simple using a git-gui manager, [SourceTree](sourcetree.com) or [GitHub Desktop](https://desktop.github.com/).
 
 **Quick setup**
-We recommend the approach in the following section, which will be most up to date, but for quick use you can use the [conda forge chanel](https://anaconda.org/conda-forge/pyepr-quantum) to install
+We recommend the approach in the following section, which will be most up to date, but for quick use you can use the [conda forge channel](https://anaconda.org/conda-forge/pyepr-quantum) to install
 ```
 conda install -c conda-forge pyepr-quantum
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ Main installation method
 
 .. _install-via_pip:
 
-Installing locally with via pip
+Installing locally via pip
 ===============================
 
 In the future, ``pyEPR`` can be installed using the Python package manager `pip <http://www.pip-installer.org/>`_.
@@ -71,8 +71,20 @@ For Python 3.6+, installation via conda is supported since ``pyEPR`` v.0.8.03, t
 
 The prefix ``-c conda-forge`` is required to activate the optional ``conda-forge`` channel.
 
-Note that the name of the recipe on the ``conda-forge`` channel is
-`pyepr-quantum`_, as the name `pyepr` was already taken by another project. This does not change anything in the way the library is imported in Python as documented in the examples.
+.. _install-via_pypi:
+
+Installing via pip from PyPI
+============================
+
+For Python 3.6+, installation via PyPI is supported since ``pyEPR`` v.0.8. You can download and install ``pyEPR`` typing in from bash with:
+
+.. code-block:: bash
+
+    pip install pyEPR-quantum
+
+.. note::
+
+  Note that the name of the recipe on the ``conda-forge`` channel is `pyepr-quantum`_, and on PyPI it is `pyEPR-quantum`, as the name `pyepr` was already taken by another project. This does not change anything in the way the library is imported in Python as documented in the guide and examples.
 
 .. _pyepr-quantum: https://anaconda.org/conda-forge/pyepr-quantum
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -35,7 +35,7 @@ Main installation method
 
 .. _install-via_pip:
 
-Installing lcoally with via pip
+Installing locally with via pip
 ===============================
 
 In the future, ``pyEPR`` can be installed using the Python package manager `pip <http://www.pip-installer.org/>`_.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -63,13 +63,16 @@ Now we can locally install the pyEPR module.
 Installing via conda
 ====================
 
-For Python 3.6+, installation via conda will be supported in a future version.
-
-
-In the meantime, if you are using conda, you can locally install from the cloned repo.
-Perform the steps in the :ref:`install-main` section.
-Now, you can use
+For Python 3.6+, installation via conda is supported since ``pyEPR`` v.0.8.03, through the ``conda-forge`` channel. You can download and install ``pyEPR`` typing in from the shell:
 
 .. code-block:: bash
 
-    python -m pip install -e .
+    conda install -c conda-forge pyepr-quantum
+
+The prefix ``-c conda-forge`` is required to activate the optional ``conda-forge`` channel.
+
+Note that the name of the recipe on the ``conda-forge`` channel is
+`pyepr-quantum`_, as the name `pyepr` was already taken by another project. This does not change anything in the way the library is imported in Python as documented in the examples.
+
+.. _pyepr-quantum: https://anaconda.org/conda-forge/pyepr-quantum
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -63,7 +63,7 @@ Now we can locally install the pyEPR module.
 Installing via conda
 ====================
 
-For Python 3.6+, installation via conda is supported since ``pyEPR`` v.0.8.03, through the ``conda-forge`` channel. You can download and install ``pyEPR`` typing in from the shell:
+For Python 3.6+, installation via `conda`_ is supported since ``pyEPR`` v.0.8.03, through the ``conda-forge`` channel. You can download and install ``pyEPR`` typing in from bash:
 
 .. code-block:: bash
 
@@ -76,7 +76,7 @@ The prefix ``-c conda-forge`` is required to activate the optional ``conda-forge
 Installing via pip from PyPI
 ============================
 
-For Python 3.6+, installation via PyPI is supported since ``pyEPR`` v.0.8. You can download and install ``pyEPR`` typing in from bash with:
+For Python 3.6+, installation via `PyPI`_ is supported since ``pyEPR`` v.0.8. You can download and install ``pyEPR`` typing in from bash:
 
 .. code-block:: bash
 
@@ -84,7 +84,8 @@ For Python 3.6+, installation via PyPI is supported since ``pyEPR`` v.0.8. You c
 
 .. note::
 
-  Note that the name of the recipe on the ``conda-forge`` channel is `pyepr-quantum`_, and on PyPI it is `pyEPR-quantum`, as the name `pyepr` was already taken by another project. This does not change anything in the way the library is imported in Python as documented in the guide and examples.
+  Note that the name of the recipe on the ``conda-forge`` channel is ``pyepr-quantum``, and on PyPI is ``pyEPR-quantum``, as the name `pyepr` was already taken by another project. This does not change anything in the way the library is imported in Python as documented in the guide and examples.
 
-.. _pyepr-quantum: https://anaconda.org/conda-forge/pyepr-quantum
+.. _conda: https://anaconda.org/conda-forge/pyepr-quantum
+.. _PyPI: https://pypi.org/project/pyEPR-quantum/0.8/
 


### PR DESCRIPTION
Update the information on the installation of `pyEPR` through PyPI and conda-forge in the documentation:

- Update the section about conda install in `installation.rst` 
- Add a section about PyPI install using the information in the README.md
- Add badges about conda-forge and PyPI distribution in the readme
- Fix minor typos

This PR closes issue #49. 