### PR TITLE
Make package name in setup.py match name on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 doclines = __doc__.split('\n')
 
-setup(name='pyEPR',
+setup(name='pyEPR-quantum',
       version='0.8',
       description = doclines[0],
       long_description = '\n'.join(doclines[2:]),


### PR DESCRIPTION
Closes #62 

Perhaps after this, we could release a new version. Otherwise, we can make a new conda package build with this patch. If we do make a new release, it should be at least 0.8.4 because for some reason we made the first conda package be version 0.8.03 even though the version is only 0.8 in the repo here.