### PR TITLE
Sorted Qs and freqs

### DIFF
--- a/pyEPR/core_quantum_analysis.py
+++ b/pyEPR/core_quantum_analysis.py
@@ -807,11 +807,11 @@ class QuantumAnalysis(object):
         ############################################################################
         ### Axis: Frequencies
         f0 = self.results.get_frequencies_HFSS(
-            variations=variations, vs=swp_variable).transpose()
+            variations=variations, vs=swp_variable).transpose().sort_index(key=lambda x : x.astype(int))
         f1 = self.results.get_frequencies_O1(
-            variations=variations, vs=swp_variable).transpose()
+            variations=variations, vs=swp_variable).transpose().sort_index(key=lambda x : x.astype(int))
         f_ND = self.results.get_frequencies_ND(
-            variations=variations, vs=swp_variable).transpose()
+            variations=variations, vs=swp_variable).transpose().sort_index(key=lambda x : x.astype(int))
         # changed by Asaf from f0 as not all modes are always analyzed
         mode_idx = list(f1.columns)
         n_modes = len(mode_idx)
@@ -842,7 +842,7 @@ class QuantumAnalysis(object):
         # Axis: Quality factors'
         Qs = self.get_quality_factors(swp_variable=swp_variable)
         Qs = Qs if variations is None else Qs[variations]
-        Qs = Qs.transpose()
+        Qs = Qs.transpose().sort_index(key=lambda x : x.astype(int))
 
         ax = axs[1, 0]
         ax.set_title('Quality factors')


### PR DESCRIPTION
Instead of having the sorting of the dataframe as string indices (e.g. '0', '1', '10', '2'...) it is now sorted as integers ('0', '1', '2', ... , '10').
Only relevant for >10 variations.