### PR TITLE
Tutorial2: Correct import of CalcObject to pyEPR.ansys

### DIFF
--- a/_tutorial_notebooks/Tutorial 2.  Field calculations - dielectric energy participation ratios (EPRs).ipynb
+++ b/_tutorial_notebooks/Tutorial 2.  Field calculations - dielectric energy participation ratios (EPRs).ipynb
@@ -397,7 +397,7 @@
    ],
    "source": [
     "from pyEPR.core import *\n",
-    "from pyEPR.core import CalcObject\n",
+    "from pyEPR.ansys import CalcObject\n",
     "\n",
     "self, volume = eprh, 'AllObjects'\n",
     "\n",


### PR DESCRIPTION
The class CalcObject is defined in `ansys.py`, not `core.py`. Therefore it should be `from pyEPR.ansys import CalcObject`.