### PR TITLE
Fix docstrings formatting

### DIFF
--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -1382,9 +1382,9 @@ class AnsysQ3DSetup(HfssSetup):
         '''
         Arguments:
         -----------
-            variation : an empty string returns nominal variation.
+            variation: an empty string returns nominal variation.
                         Otherwise need the list
-            frequency : in Hz
+            frequency: in Hz
             soln_type = "C", "AC RL" and "DC RL"
             solution_kind = 'LastAdaptive' # AdaptivePass
         Internals:

--- a/pyEPR/calcs/back_box_numeric.py
+++ b/pyEPR/calcs/back_box_numeric.py
@@ -86,8 +86,8 @@ def black_box_hamiltonian(fs, ljs, fzpfs, cos_trunc=5, fock_trunc=8, individual=
     All in SI units. The ZPF fed in are the generalized, not reduced, flux.
 
     Description:
-     Takes the linear mode frequencies, $\omega_m$, and the zero-point fluctuations, ZPFs, and
-     builds the Hamiltonian matrix of $H_full$, assuming cos potential.
+     Takes the linear mode frequencies, :math:`\omega_m`, and the zero-point fluctuations, ZPFs, and
+     builds the Hamiltonian matrix of :math:`H_{full}`, assuming cos potential.
     """
     n_modes = len(fs)
     njuncs = len(ljs)
@@ -145,8 +145,8 @@ def make_dispersive(H, fock_trunc, fzpfs=None, f0s=None, chi_prime=False,
     Output:
         Return dressed mode frequencies, chis, chi prime, phi_zpf flux (not reduced), and linear frequencies
     Description:
-        Takes the Hamiltonian matrix `H` from bbq_hmt. It them finds the eigenvalues/eigenvectors and  assigns quantum numbers to them --- i.e., mode excitations,  such as, for instance, for three mode, |0,0,0> or |0,0,1>, which correspond to no excitations in any of the modes or one excitation in the 3rd mode, resp.    The assignment is performed based on the maximum overlap between the eigenvectors of H_full and H_lin.   If this crude explanation is confusing, let me know, I will write a more detailed one :slightly_smiling_face:
-        Based on the assignment of the excitations, the function returns the dressed mode frequencies $\omega_m^\prime$, and the cross-Kerr matrix (including anharmonicities) extracted from the numerical diagonalization, as well as from 1st order perturbation theory.
+        Takes the Hamiltonian matrix `H` from bbq_hmt. It them finds the eigenvalues/eigenvectors and  assigns quantum numbers to them --- i.e., mode excitations,  such as, for instance, for three mode, :math:`|0,0,0\rangle` or :math:`|0,0,1\rangle`, which correspond to no excitations in any of the modes or one excitation in the 3rd mode, resp.    The assignment is performed based on the maximum overlap between the eigenvectors of H_full and H_lin.   If this crude explanation is confusing, let me know, I will write a more detailed one |:slightly_smiling_face:|
+        Based on the assignment of the excitations, the function returns the dressed mode frequencies :math:`\omega_m^\prime`, and the cross-Kerr matrix (including anharmonicities) extracted from the numerical diagonalization, as well as from 1st order perturbation theory.
         Note, the diagonal of the CHI matrix is directly the anharmonicity term.
     """
     if hasattr(H, '__len__'):  # is it an array / list?
@@ -154,7 +154,7 @@ def make_dispersive(H, fock_trunc, fzpfs=None, f0s=None, chi_prime=False,
         H = H_lin + H_nl
     else:  # make sure its a quanutm object
         assert type(
-            H) == qutip.qobj.Qobj, "Please pass in either  a list of Qobjs or Qobj for the Hamiltonian"
+            H) == qutip.qobj.Qobj, "Please pass in either a list of Qobjs or Qobj for the Hamiltonian"
 
     print("Starting the diagonalization")
     evals, evecs = H.eigenstates()

--- a/pyEPR/calcs/basic.py
+++ b/pyEPR/calcs/basic.py
@@ -11,15 +11,14 @@ class CalcsBasic():
     @staticmethod
     def epr_to_zpf(Pmj, SJ, Ω, EJ):
         r'''
-        INPUTS:
-            All as matrices (numpy arrays)
+        Arguments, All as matrices (numpy arrays):
             :Pnj: MxJ energy-participation-ratio matrix, p_mj
             :SJ: MxJ sign matrix, s_mj
             :Ω: MxM diagonal matrix of frequencies (GHz, not radians, diagonal)
             :EJ: JxJ diagonal matrix matrix of Josephson energies (in same units as Om)
 
         RETURNS:
-            reduced zpf  (in units of $\phi_0$)
+            reduced zpf  (in units of :math:`\phi_0`)
         '''
         (Pmj, SJ, Ω, EJ) = map(np.array, (Pmj, SJ, Ω, EJ))
 

--- a/pyEPR/calcs/convert.py
+++ b/pyEPR/calcs/convert.py
@@ -25,13 +25,13 @@ class Convert():
         Static container class for conversions of units and variables.
 
         TEST CONVERSION:
-        ```python
-            from pyEPR.toolbox.conversions import Convert
 
-            Lj_nH, Cs_fF = 11, 60
-            Convert.transmon_print_all_params(Lj_nH, Cs_fF);
+        .. code-block:: python
 
-        ```
+           from pyEPR.toolbox.conversions import Convert
+           
+           Lj_nH, Cs_fF = 11, 60
+           Convert.transmon_print_all_params(Lj_nH, Cs_fF);
     '''
     # Known SI prefixed
     _prefix = {'y': -24,  # yocto
@@ -109,7 +109,7 @@ class Convert():
         Josephson Junction energy from Josephson inductance.
         Returns in MHz
 
-        $E_j = \phi_0^2 / L_J$
+        :math:`E_j = \phi_0^2 / L_J`
         '''
         return Convert._convert_num(
             # Plank to go from Joules to Hz
@@ -122,7 +122,7 @@ class Convert():
         Josephson Junction ind from Josephson energy in MHZ.
         Returns in units of nano Henries by default
 
-        $E_j = \phi_0^2 / L_J$
+        :math:`E_j = \phi_0^2 / L_J`
         '''
         return Convert._convert_num(
             lambda _x: (ϕ0**2.)/(_x*Planck),  # Plank to go from Joules to Hz
@@ -133,7 +133,7 @@ class Convert():
         r'''
         Josephson Junction crit. curr from Josephson inductance.
 
-        $E_j = \phi_0^2 / L_J = \phi_0 I_C $
+        :math:`E_j = \phi_0^2 / L_J = \phi_0 I_C`
         '''
         return Convert._convert_num(
             lambda _x: ϕ0/_x,  # Plank to go from Joules to Hz
@@ -144,7 +144,7 @@ class Convert():
         r'''
         Josephson Junction crit. curr from Josephson inductance.
 
-        $E_j = \phi_0^2 / L_J = \phi_0 I_C $
+        :math:`E_j = \phi_0^2 / L_J = \phi_0 I_C`
         '''
         return Convert._convert_num(
             lambda _x: ϕ0/_x,  # Plank to go from Joules to Hz
@@ -153,10 +153,10 @@ class Convert():
     @staticmethod
     def Ec_from_Cs(Cs,  units_in='fF', units_out='MHz'):
         r'''
-        Charging energy 4Ec n^2, where n=Q/2e
+        Charging energy :math:`4E_c n^2`, where :math:`n=Q/2e`
         Returns in MHz
 
-        $E_{C}=\frac{e^{2}}{2C}J$
+        :math:`E_{C}=\frac{e^{2}}{2C}J`
         '''
         return Convert._convert_num(
             # Plank to go from Joules to Hz
@@ -166,11 +166,11 @@ class Convert():
     @staticmethod
     def Cs_from_Ec(Ec, units_in='MHz', units_out='fF'):
         r'''
-        Charging energy 4Ec n^2, where n=Q/2e
+        Charging energy :math:`4E_c n^2`, where :math:`n=Q/2e`
 
         Returns in SI units, in Farads.
 
-        $E_{C}=\frac{e^{2}}{2C}J$
+        :math:`E_{C}=\frac{e^{2}}{2C}J`
         '''
         return Convert._convert_num(
             # Plank to go from Joules to Hz

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -537,7 +537,7 @@ class DistributedAnalysis(object):
         """
         Get ansys variables
 
-        Return HFSS variable from self.get_ansys_variables() as a
+        Return HFSS variable from :py:func:`self.get_ansys_variables()` as a
         pandas series vs variations.
 
         Args:
@@ -727,14 +727,13 @@ class DistributedAnalysis(object):
         '''
         Peak current I_max for prespecified mode calculating line voltage across junction.
 
-        Make sure that oyu have set the correct variation in hFSS before running this
+        Make sure that you have set the correct variation in HFSS before running this
 
-        Parameters:
-        ------------------------------------------------
+        Args:
             variation: variation number
             junc_line_name: name of the HFSS line spanning the junction
             junc_L_Henries: junction inductance in henries
-            Cj_Farads : junction cap in Farads
+            Cj_Farads: junction cap in Farads
             TODO: Smooth?
         '''
         lv = self._get_lv(variation)
@@ -958,14 +957,13 @@ class DistributedAnalysis(object):
             variation (str): A string identifier of the variation,
             such as '0', '1', ...
 
-        Note:
-        --------------
-            U_E and U_H are the total peak energy. (NOT twice as in U_ and U_H other places)
+        .. note::
+           U_E and U_H are the total peak energy. (NOT twice as in U_ and U_H other places)
 
-
-        Potential errors:  If you dont have a line or rect by the right name you will prob
-        get an error of the type:
-        com_error: (-2147352567, 'Exception occurred.', (0, None, None, None, 0, -2147024365), None)
+        .. warning::
+           Potential errors: If you dont have a line or rect by the right name you will prob
+           get an error of the type: com_error: (-2147352567, 'Exception occurred.', 
+           (0, None, None, None, 0, -2147024365), None)
         '''
 
         # ------------------------------------------------------------
@@ -1115,7 +1113,7 @@ class DistributedAnalysis(object):
 
         Args:
             variation (str): A string identifier of the variation,
-            such as '0', '1', ...
+                such as '0', '1', ...
 
         Optional Parameters:
         ------------------------
@@ -1127,8 +1125,8 @@ class DistributedAnalysis(object):
                 Modes to analyze
                 for example  modes = [0, 2, 3]
 
-            append_analysis (bool) : When we run the ansys analysis, should we redo any variations
-                 that we have already done?
+            append_analysis (bool) : 
+                When we run the Ansys analysis, should we redo any variations that we have already done?
 
         Ansys Notes:
         ------------------------


### PR DESCRIPTION
This PR fixes errors in docstrings formatting, including:
* Markdown style code-blocks to rst
* LaTeX `$$` changed with rst ` :math:`` `

Drafted until more docstrings are checked

Closes #100 