### PR TITLE
Add dissipative elements as arguments to `ProjectInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,16 @@ pinfo.junctions['jBob']   = {'Lj_variable':'Lj_bob',   'rect':'rect_bob',   'lin
 pinfo.validate_junction_info() # Check that valid names of variables and objects have been supplied.
 
 # 2b. Dissipative elements: specify
-pinfo.dissipative['dielectrics_bulk']    = ['si_substrate', 'dielectic_object2'] # supply names of hfss objects
+pinfo.dissipative['dielectrics_bulk']    = ['si_substrate', 'dielectric_object2'] # supply names of hfss objects
 pinfo.dissipative['dielectric_surfaces'] = ['interface1', 'interface2']
+# Alternatively, these could be specified in ProjectInfo with
+# pinfo = epr.ProjectInfo(..., dielectrics_bulk = ['si_substrate', 'dielectric_object2'])
 
 # 3.  Perform microwave analysis on eigenmode solutions
 eprd = epr.DistributedAnalysis(pinfo)
 if 1: # automatic reports
   eprd.quick_plot_frequencies(swp_var) # plot the solved frequencies before the analysis
-  eprd.hfss_report_full_convergence() # report convergen
+  eprd.hfss_report_full_convergence() # report convergence
 eprd.do_EPR_analysis()
 
 # 4a.  Perform Hamiltonian spectrum post-analysis, building on mw solutions using EPR

--- a/_tutorial_notebooks/Tutorial 1.  Startup example.ipynb
+++ b/_tutorial_notebooks/Tutorial 1.  Startup example.ipynb
@@ -867,7 +867,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Q is infinite, since we have not included dissipation yet in this example. The row index is the mode number"
+    "The Q is infinite, since we have not included dissipation yet in this example. The row index is the mode number. Dissipation can be modelled by selecting the corresponding HFSS objects for solids, sheets, and seams when initialising `ProjectInfo`. For example,\n",
+    "```python\n",
+    "pinfo = epr.ProjectInfo(project_path = path_to_project, \n",
+    "                        project_name = 'pyEPR_tutorial1',\n",
+    "                        design_name  = '1. single_transmon',\n",
+    "                        dielectrics_bulk = ['si_substrate'],\n",
+    "                        dielectric_surfaces = ['interface'],\n",
+    "                        resistive_surfaces = None,\n",
+    "                        seams = None)\n",
+    "```\n",
+    "or after the fact with\n",
+    "```python\n",
+    "pinfo.dissipative['dielectrics_bulk'] = ['si_substrate']\n",
+    "pinfo.dissipative['dielectric_surfaces'] = ['interface']\n",
+    "```"
    ]
   },
   {

--- a/docs/source/examples_quick.rst
+++ b/docs/source/examples_quick.rst
@@ -29,14 +29,16 @@ succinctly plotted.
     pinfo.validate_junction_info() # Check that valid names of variables and objects have been supplied.
 
     # 2b. Dissipative elements: specify
-    pinfo.dissipative['dielectrics_bulk']    = ['si_substrate', 'dielectic_object2'] # supply names of hfss objects
+    pinfo.dissipative['dielectrics_bulk']    = ['si_substrate', 'dielectric_object2'] # supply names of hfss objects
     pinfo.dissipative['dielectric_surfaces'] = ['interface1', 'interface2']
+    # Alternatively, these could be specified in ProjectInfo with
+    # pinfo = epr.ProjectInfo(..., dielectrics_bulk = ['si_substrate', 'dielectric_object2'])
 
     # 3.  Perform microwave analysis on eigenmode solutions
     eprd = epr.DistributedAnalysis(pinfo)
     swp_var = 'Lj_alice' # Sweep variable from optimetric analysis that should be used on the x axis for the frequency plot
     eprd.quick_plot_frequencies(swp_var) # plot the solved frequencies before the analysis
-    eprd.hfss_report_full_convergence() # report convergen
+    eprd.hfss_report_full_convergence() # report convergence
     eprd.do_EPR_analysis()
 
     # 4a.  Perform Hamiltonian spectrum post-analysis, building on mw solutions using EPR

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -70,7 +70,7 @@ class DistributedAnalysis(object):
 
         Use notes:
         -------------------
-            * If you change the setup or number of eignemodes in HFSS, etc.
+            * If you change the setup or number of eigenmodes in HFSS, etc.
               call `update_ansys_info()`
 
 

--- a/pyEPR/project_info.py
+++ b/pyEPR/project_info.py
@@ -165,6 +165,10 @@ class ProjectInfo(object):
                  project_name: str = None,
                  design_name: str = None,
                  setup_name: str = None,
+                 dielectrics_bulk: list[str] = None,
+                 dielectric_surfaces: list[str] = None,
+                 resistive_surfaces: list[str] = None,
+                 seams: list[str] = None,
                  do_connect: bool = True):
         """
         Keyword Arguments:
@@ -179,7 +183,14 @@ class ProjectInfo(object):
                 Defaults to ``None``, which will get the current active one.
             setup_name  (str) :  Name of the setup within the design.
                 Defaults to ``None``, which will get the current active one.
-
+            dielectrics_bulk (list(str)) : List of names of dielectric bulk objects.
+                Defaults to ``None``.
+            dielectric_surfaces (list(str)) : List of names of dielectric surfaces.
+                Defaults to ``None``.
+            resistive_surfaces (list(str)) : List of names of resistive surfaces.
+                Defaults to ``None``.
+            seams (list(str)) : List of names of seams.
+                Defaults to ``None``.
             do_connect (bool) [additional]: Do create connection to Ansys or not? Defaults to ``True``.
         
         """
@@ -198,6 +209,8 @@ class ProjectInfo(object):
 
         # Dissipative HFSS volumes and surfaces
         self.dissipative = self._Dissipative()
+        for opt in diss_opt:
+            self.dissipative[opt] = locals()[opt]
         self.options = config.ansys
 
         # Connected to HFSS variable


### PR DESCRIPTION
This PR implements adding dissipative elements as arguments to `ProjectInfo` as suggested in #102. Is this an okay design choice?

Closes #102 