### PR TITLE
Test compiling docs in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 env:
   # Increment this to invalidate the cache without modifying requirements.txt
   PIPCACHEVERSION: 0
+  PYTHONVERSION: '3.9.x'  # qutip does not support 3.10 yet
 
 jobs:
   pylint:
@@ -20,8 +21,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          # qutip does not support 3.10 yet
-          python-version: '3.9.x'
+          python-version: ${{ env.PYTHONVERSION }}
       - name: Set up cache
         id: cache
         uses: actions/cache@v2
@@ -35,3 +35,36 @@ jobs:
         run: python -m pip install . pylint
       - name: Run pylint
         run: pylint --errors-only --jobs=0 pyEPR
+
+  test_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHONVERSION }}
+      - name: Set up cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-${{ env.PIPCACHEVERSION }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}-
+            ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-
+      - name: Install package and sphinx
+        run: python -m pip install . Sphinx
+      - name: Make docs
+        run: |
+          cd docs
+          make html
+      - name: Upload docs to artifact
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: docs
+          path: docs/build/html/
+          retention-days: 5


### PR DESCRIPTION
This PR adds compiling of documentation to CI, so that it can be downloaded and changes seen more easily. It further check if the documentation would fail due to changes.

I set the artifact retention to 5 days but it could be lower as well.