### PR TITLE
Replace attrdict to addict for python 3.10 compatibility

### DIFF
--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -74,13 +74,7 @@ import logging
 import warnings
 from pathlib import Path
 
-try:
-    from attrdict import AttrDict as Dict
-except (ImportError, ModuleNotFoundError):
-    raise ImportError("""Please install python package `AttrDict`.
-    AttrDict is in PyPI, so it can be installed directly
-    (https://github.com/bcj/AttrDict) using:
-        $ pip install attrdict""")
+from addict import Dict
 
 ##############################################################################
 # Python header

--- a/pyEPR/toolbox/pythonic.py
+++ b/pyEPR/toolbox/pythonic.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 # Constants
 from collections import OrderedDict
 from ..calcs.constants import Planck, elementary_charge, epsilon_0, pi, π, ħ, ϕ0, e_el
-
+from .. import Dict
 
 # ==============================================================================
 # Utility functions
@@ -177,8 +177,10 @@ def get_instance_vars(obj, Forbidden=[]):
     for v in dir(obj):
         if not (v.startswith('__') or v.startswith('_')):
             if not callable(getattr(obj, v)):
-                if not (v in Forbidden):
-                    VARS[v] = getattr(obj, v)
+                # Added for using addict.Dict which is not callable. 
+                if not isinstance(getattr(obj, v), Dict):
+                    if not (v in Forbidden):
+                        VARS[v] = getattr(obj, v)
     return VARS
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrdict>=1.8.0
+addict
 numpy>=1.15.0
 pandas>=1.0.1
 matplotlib>=3.1.0

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering", "Environment :: Console",
         "License :: OSI Approved :: Apache Software License"

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering", "Environment :: Console",
         "License :: OSI Approved :: Apache Software License"
     ],


### PR DESCRIPTION
This PR replaces library attrdict to addict for python 3.10 compatibility. 

It's related to issue #106.