### PR TITLE
Add DrivenTerminal support

### DIFF
--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -715,6 +715,8 @@ class HfssDesign(COMWrapper):
             return HfssEMSetup(self, name)
         elif self.solution_type == "DrivenModal":
             return HfssDMSetup(self, name)
+        elif self.solution_type == "DrivenTerminal":
+            return HfssDTSetup(self, name)
         elif self.solution_type == "Q3D":
             return AnsysQ3DSetup(self, name)
 
@@ -764,6 +766,26 @@ class HfssDesign(COMWrapper):
             pct_refinement, "IsEnabled:=", True, "BasisOrder:=", basis_order
         ])
         return HfssDMSetup(self, name)
+
+    def create_dt_setup(self,
+                        freq_ghz=1,
+                        name="Setup",
+                        max_delta_s=0.1,
+                        max_passes=10,
+                        min_passes=1,
+                        min_converged=1,
+                        pct_refinement=30,
+                        basis_order=-1):
+
+        name = increment_name(name, self.get_setup_names())
+        self._setup_module.InsertSetup("HfssDriven", [
+            "NAME:" + name, "Frequency:=",
+            str(freq_ghz) + "GHz", "MaxDeltaS:=", max_delta_s,
+            "MaximumPasses:=", max_passes, "MinimumPasses:=", min_passes,
+            "MinimumConvergedPasses:=", min_converged, "PercentRefinement:=",
+            pct_refinement, "IsEnabled:=", True, "BasisOrder:=", basis_order
+        ])
+        return HfssDTSetup(self, name)
 
     def create_em_setup(self,
                         name="Setup",
@@ -1331,6 +1353,11 @@ class HfssDMSetup(HfssSetup):
     def get_solutions(self):
         return HfssDMDesignSolutions(self, self.parent._solutions)
 
+class HfssDTSetup(HfssDMSetup):
+
+    def get_solutions(self):
+        return HfssDTDesignSolutions(self, self.parent._solutions)
+
 
 class HfssEMSetup(HfssSetup):
     """
@@ -1724,6 +1751,8 @@ class HfssEMDesignSolutions(HfssDesignSolutions):
 class HfssDMDesignSolutions(HfssDesignSolutions):
     pass
 
+class HfssDTDesignSolutions(HfssDesignSolutions):
+    pass
 
 class HfssQ3DDesignSolutions(HfssDesignSolutions):
     pass

--- a/pyEPR/project_info.py
+++ b/pyEPR/project_info.py
@@ -319,18 +319,20 @@ class ProjectInfo(object):
 
                 if len(setup_names) == 0:
                     logger.warning('\tNo design setup detected.')
+                    setup = None
                     if self.design.solution_type == 'Eigenmode':
                         logger.warning('\tCreating eigenmode default setup.')
                         setup = self.design.create_em_setup()
-                        self.setup_name = setup.name
                     elif self.design.solution_type == 'DrivenModal':
-                        logger.warning('\tCreating drivenmodal default setup.')
+                        logger.warning('\tCreating driven modal default setup.')
                         setup = self.design.create_dm_setup()
-                        self.setup_name = setup.name
+                    elif self.design.solution_type == 'DrivenTerminal':
+                        logger.warning('\tCreating driven terminal default setup.')
+                        setup = self.design.create_dt_setup()
                     elif self.design.solution_type == 'Q3D':
                         logger.warning('\tCreating Q3D default setup.')
                         setup = self.design.create_q3d_setup()
-                        self.setup_name = setup.name
+                    self.setup_name = setup.name
                 else:
                     self.setup_name = setup_names[0]
 


### PR DESCRIPTION
This PR adds support for HFSS Driven Terminal solutions. There doesn't seem to be API differences compared to Driven Modal that would need to be taken care of by pyEPR.

As such, the new `HfssDTSetup` is effectively the same as `HfssDMSetup`. We just have to have the check for `solution_type == "DrivenTerminal"`, otherwise pyEPR fails to connect to Ansys
```python
        elif self.solution_type == "DrivenTerminal":
            return HfssDTSetup(self, name)
```

Closes #120 