### PR TITLE
Fix EPR bug and bump to version 0.8.5.7

### DIFF
--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -59,7 +59,7 @@ Automated analysis of lumped and distributed circuits is provided.
 @author: Zlatko Minev, Zaki Leghas, ... and the pyEPR team
 @site: https://github.com/zlatko-minev/pyEPR
 @license: "BSD-3-Clause"
-@version: 0.8.5.6
+@version: 0.8.5.7
 @maintainer: Zlatko K. Minev and  Asaf Diringer
 @email: zlatko.minev@aya.yale.edu
 @url: https://github.com/zlatko-minev/pyEPR

--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -86,7 +86,7 @@ __credits__ = [
     "Will Livingston", "Steven Touzard"
 ]
 __license__ = "BSD-3-Clause"
-__version__ = "0.8.5.6"
+__version__ = "0.8.5.7"
 __maintainer__ = "Zlatko K. Minev and  Asaf Diringer"
 __email__ = "zlatko.minev@aya.yale.edu"
 __url__ = r'https://github.com/zlatko-minev/pyEPR'

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -742,7 +742,7 @@ class DistributedAnalysis(object):
             "E").real().integrate_line_tangent(name=junc_line_name)
         v_calc_imag = CalcObject([], self.setup).getQty(
             "E").imag().integrate_line_tangent(name=junc_line_name)
-        V = np.sign(v_calc_real) * np.sqrt(v_calc_real.evaluate(lv=lv)**2 +
+        V = np.sign(v_calc_real.evaluate()) * np.sqrt(v_calc_real.evaluate(lv=lv)**2 +
                     v_calc_imag.evaluate(lv=lv)**2)
 
         # Get frequency

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -742,7 +742,7 @@ class DistributedAnalysis(object):
             "E").real().integrate_line_tangent(name=junc_line_name)
         v_calc_imag = CalcObject([], self.setup).getQty(
             "E").imag().integrate_line_tangent(name=junc_line_name)
-        V = np.sign(v_calc_real.evaluate()) * np.sqrt(v_calc_real.evaluate(lv=lv)**2 +
+        V = np.sign(v_calc_real.evaluate(lv=lv)) * np.sqrt(v_calc_real.evaluate(lv=lv)**2 +
                     v_calc_imag.evaluate(lv=lv)**2)
 
         # Get frequency

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ doclines = __doc__.split('\n')
 
 setup(
     name='pyEPR-quantum',
-    version='0.8.5.6',
+    version='0.8.5.7',
     description=doclines[0],
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Version 0.8.5.6 didn't evaluate the real part of the voltage, so we need to add in .evaluate() as shown in this commit. This commit also changes the version number to 0.8.5.7