### PR TITLE
Don't extend `hfss_report_full_convergence` vertically

### DIFF
--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -1625,7 +1625,7 @@ class DistributedAnalysis(object):
             convergence_t = self.get_convergence(variation=variation)
             convergence_f = self.hfss_report_f_convergence(variation=variation)
 
-            axs[0].set_ylabel(variation_labels, fontsize='large')  # add variation labels to y-axis of first plot
+            axs[0].set_ylabel(variation_labels.replace(' ', '\n'))  # add variation labels to y-axis of first plot
 
             ax0t = axs[1].twinx()
             plot_convergence_f_vspass(axs[0], convergence_f)


### PR DESCRIPTION
This PR edits `hfss_report_full_convergence` labels modified in #119 to not overtake the screen if there are a lot of variables. Previously, these would all be on a single line, now all the variables are on their own line.

# Before

Atrocious

![image](https://user-images.githubusercontent.com/7860886/183921725-28cf2e43-9e23-4160-bb9c-17dabb11a265.png)


# After

Looks decent even with floats like this

![image](https://user-images.githubusercontent.com/7860886/183921067-d3aa8929-9a9d-4970-9c8d-b228b7508400.png)
