### PR TITLE
Refactor `DataFrame.append` to `pd.concat`

### DIFF
--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -1299,19 +1299,17 @@ class DistributedAnalysis(object):
                 # get seam Q
                 if self.pinfo.dissipative['seams']:
                     for seam in self.pinfo.dissipative['seams']:
-                        sol = sol.append(self.get_Qseam(seam, mode, variation, self.U_H))
+                        sol = pd.concat([sol, self.get_Qseam(seam, mode, variation, self.U_H)])
 
                 # get Q dielectric
                 if self.pinfo.dissipative['dielectrics_bulk']:
                     for dielectric in self.pinfo.dissipative['dielectrics_bulk']:
-                        sol = sol.append(self.get_Qdielectric(
-                            dielectric, mode, variation, self.U_E))
+                        sol = pd.concat([sol, self.get_Qdielectric(dielectric, mode, variation, self.U_E)])
 
                 # get Q surface
                 if self.pinfo.dissipative['resistive_surfaces']:
                     if self.pinfo.dissipative['resistive_surfaces'] == 'all':
-                        sol = sol.append(
-                            self.get_Qsurface_all(mode, variation, self.U_E))
+                        sol = pd.concat([sol, self.get_Qsurface_all(mode, variation, self.U_E)])
                     else:
                         raise NotImplementedError(
                             "Join the team, by helping contribute this piece of code.")


### PR DESCRIPTION
This resolves the following warnings emerging during EPR analysis
```
pyepr\pyEPR\core_distributed_analysis.py:1307: FutureWarning: The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  sol = sol.append(self.get_Qdielectric(
```

Closes #136 