### PR TITLE
Replace usage of np.float with float (#147)

### DIFF
--- a/pyEPR/calcs/back_box_numeric.py
+++ b/pyEPR/calcs/back_box_numeric.py
@@ -63,7 +63,7 @@ def epr_numerical_diagonalization(freqs, Ljs, ϕzpf,
     assert(all(Ljs < 1E-3)
            ), "Please input the inductances in Henries. \N{nauseated face}"
 
-    Hs = black_box_hamiltonian(freqs * 1E9, Ljs.astype(np.float), fluxQ*ϕzpf,
+    Hs = black_box_hamiltonian(freqs * 1E9, Ljs.astype(float), fluxQ*ϕzpf,
                                cos_trunc, fock_trunc, individual=use_1st_order,
                                non_linear_potential = non_linear_potential)
     f_ND, χ_ND, _, _ = make_dispersive(


### PR DESCRIPTION
Fixes issue #147 

The `epr_numerical_diagonalization` function uses `np.float` which has been deprecated in Numpy.

Refer https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

The continued usage of `np.float` yields the following error in the `epr_numerical_diaganolization` function when later versions (tested on v1.24.2) of Numpy is used.

```
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. 
To avoid this error in existing code, use `float` by itself. 
Doing this will not modify any behavior and is safe. 
If you specifically wanted the numpy scalar type, use `np.float64` here.
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.
```

This PR replaces `np.float` with `float` to solve this error.