### PR TITLE
Fix report v2022

### DIFF
--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -3207,7 +3207,8 @@ def get_report_arrays(name: str):
 
 def load_ansys_project(proj_name: str,
                        project_path: str = None,
-                       extension: str = '.aedt'):
+                       extension: str = '.aedt', 
+                       version = 'AnsoftHfss.HfssScriptInterface'):
     '''
     Utility function to load an Ansys project.
 
@@ -3238,7 +3239,7 @@ def load_ansys_project(proj_name: str,
                 '\t\tFile is locked. \N{fearful face} If connection fails, delete the .lock file.'
             )
 
-    app = HfssApp()
+    app = HfssApp(ProgID = version)
     logger.info("\tOpened Ansys App")
 
     desktop = app.get_app_desktop()

--- a/pyEPR/core_quantum_analysis.py
+++ b/pyEPR/core_quantum_analysis.py
@@ -662,7 +662,8 @@ class QuantumAnalysis(object):
             EJ = EJ[:, junctions][junctions, :]
             PHI_zpf = PHI_zpf[:, junctions]
             PJ_cap = PJ_cap[:, junctions]
-
+        
+        """ NOTE: modes is never None because of the None-check above
         if modes is not None:
             freqs_hfss = freqs_hfss[range(len(self.modes[variation])), ]
             PJ = PJ[range(len(modes)), :]
@@ -670,6 +671,13 @@ class QuantumAnalysis(object):
             Om = Om[range(len(modes)), :][:, range(len(modes))]
             PHI_zpf = PHI_zpf[range(len(modes)), :]
             PJ_cap = PJ_cap[:, junctions]
+        """
+        freqs_hfss = freqs_hfss[range(len(self.modes[variation])), ]
+        PJ = PJ[modes, :]
+        SJ = SJ[modes, :]
+        Om = Om[modes, :][:, modes]
+        PHI_zpf = PHI_zpf[modes, :]
+        PJ_cap = PJ_cap[:, junctions]
 
         # Analytic 4-th order
         CHI_O1 = 0.25 * Om @ PJ @ inv(EJ) @ PJ.T @ Om * 1000.  # MHz

--- a/pyEPR/project_info.py
+++ b/pyEPR/project_info.py
@@ -169,7 +169,8 @@ class ProjectInfo(object):
                 dielectric_surfaces: list = None,
                 resistive_surfaces: list= None,
                 seams: list= None,
-                do_connect: bool = True):
+                do_connect: bool = True, 
+                version = 'AnsoftHfss.HfssScriptInterface'):
         """
         Keyword Arguments:
 
@@ -201,6 +202,7 @@ class ProjectInfo(object):
         self.project_name = project_name
         self.design_name = design_name
         self.setup_name = setup_name
+        self.version = version
 
         # HFSS design: describe junction parameters
         # TODO: introduce modal labels
@@ -252,7 +254,7 @@ class ProjectInfo(object):
         logger.info('Connecting to Ansys Desktop API...')
 
         self.app, self.desktop, self.project = ansys.load_ansys_project(
-            self.project_name, self.project_path)
+            self.project_name, self.project_path, version = self.version)
 
         if self.project:
             # TODO: should be property?


### PR DESCRIPTION
This PR fixes the issue that arising in 'hfss_report_full_convergence' when using Ansys Electronic Desktop version 2022+. This issue is caused by a change in trace-name which includes the full variation string (but formatted) in version 2022+.
Additionally, there are a couple commits that allows the used to select which Ansys ED version to use in case there are multiple version installed. 