### PR TITLE
Fixed missing return in get_exciations and wrong coordinate assignment in create_relative_coorinate_system_both

### DIFF
--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -2978,7 +2978,7 @@ class HfssModeler(COMWrapper):
                 "YAxisYvec:=",
                 YAxisVec[1],
                 "YAxisZvec:=",
-                YAxisVec[1],
+                YAxisVec[2],
             ],
             ["NAME:Attributes", "Name:=", cs_name],
         )

--- a/pyEPR/ansys.py
+++ b/pyEPR/ansys.py
@@ -1086,7 +1086,7 @@ class HfssDesign(COMWrapper):
             self.set_variable(name, value)
 
     def get_excitations(self):
-        self._boundaries.GetExcitations()
+        return self._boundaries.GetExcitations()
 
     def _evaluate_variable_expression(self, expr, units):
         """


### PR DESCRIPTION
Additionally, there appears to be a typo in the method name `create_relative_coorinate_system_both` in `HfssModeler` in `ansys.py`. I intentionally did not rename it to avoid breaking backward compatibility.
