### PR TITLE
Fix qutip 5.x API breaks, add Hamiltonian tests, update publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,51 +1,32 @@
-# This is a basic workflow to help you get started with Actions
+name: Publish to PyPI
 
-name: Publish Python 🐍 distributions 📦 to PyPI 
-
-# Controls when the action will run. 
 on:
   release:
     types: [created]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    # The type of runner that the job will run on
+  build-and-publish:
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@master
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-          
-      - name: Install pypa/build
-        run: >-
-          python -m
-          pip install
-          build
-          --user
+      - uses: actions/checkout@v4
 
-      - name: Build a binary wheel and a source tarball
-        run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
-          .
-
-      - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          password: ${{ secrets.pypi_password }}
-      
+          python-version: "3.12"
+
+      - name: Install build
+        run: python -m pip install build --user
+
+      - name: Build sdist and wheel
+        run: python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyEPR/calcs/back_box_numeric.py
+++ b/pyEPR/calcs/back_box_numeric.py
@@ -174,13 +174,13 @@ def make_dispersive(
         Based on the assignment of the excitations, the function returns the dressed mode frequencies :math:`\omega_m^\prime`, and the cross-Kerr matrix (including anharmonicities) extracted from the numerical diagonalization, as well as from 1st order perturbation theory.
         Note, the diagonal of the CHI matrix is directly the anharmonicity term.
     """
-    if hasattr(H, "__len__"):  # is it an array / list?
+    if isinstance(H, (list, tuple)):  # [H_lin, H_nl] from individual=True
         [H_lin, H_nl] = H
         H = H_lin + H_nl
-    else:  # make sure its a quanutm object
+    else:  # make sure its a quantum object
         from qutip import Qobj
 
-        if not isinstance(H, Qobj):  #  Validate that the input is a Qobj instance.
+        if not isinstance(H, Qobj):  # Validate that the input is a Qobj instance.
             raise TypeError(
                 "Please pass in either a list of Qobjs or a Qobj for the Hamiltonian"
             )
@@ -221,7 +221,9 @@ def make_dispersive(
             """this function generates all possible multi-indices for three modes for a given fock_trunc"""
 
         def get_expect_number(left, middle, right):
-            return (left.dag() * middle * right).data.toarray()[0, 0]
+            result = left.dag() * middle * right
+            # qutip 4: returns 1x1 Qobj; qutip 5: returns complex scalar
+            return result.full()[0, 0] if hasattr(result, "full") else complex(result)
             """this function calculates the expectation value of an operator called "middle" """
 
         def get_basis0(fock_trunc, num_modes):
@@ -239,15 +241,10 @@ def make_dispersive(
                 new_vector = 0 * original_vector
                 for i in range(len(original_basis)):
                     if (energy0[i] - evalue) > 1e-3:
-                        new_vector += (
-                            (
-                                (
-                                    original_basis[i].dag() * H_nl * original_vector
-                                ).data.toarray()[0, 0]
-                            )
-                            * original_basis[i]
-                            / (evalue - energy0[i])
-                        )
+                        mel = original_basis[i].dag() * H_nl * original_vector
+                        # qutip 4: 1x1 Qobj; qutip 5: complex scalar
+                        mel = mel.full()[0, 0] if hasattr(mel, "full") else complex(mel)
+                        new_vector += mel * original_basis[i] / (evalue - energy0[i])
                     else:
                         pass
                 return (new_vector + original_vector) / (

--- a/pyEPR/calcs/hamiltonian.py
+++ b/pyEPR/calcs/hamiltonian.py
@@ -59,7 +59,9 @@ class HamOps(object):
         """
 
         def distance(s2):
-            return (s.dag() * s2[1]).norm()
+            inner = s.dag() * s2[1]
+            # qutip 4 returns a 1x1 Qobj (.norm()); qutip 5 returns a complex scalar (abs())
+            return inner.norm() if hasattr(inner, "norm") else abs(inner)
 
         return max(zip(energyMHz, evecs), key=distance)
 
@@ -70,7 +72,9 @@ class HamOps(object):
         """
 
         def distance(s2):
-            return (s.dag() * s2[1]).norm()
+            inner = s.dag() * s2[1]
+            # qutip 4 returns a 1x1 Qobj (.norm()); qutip 5 returns a complex scalar (abs())
+            return inner.norm() if hasattr(inner, "norm") else abs(inner)
 
         return max(zip(range(len(evecs)), evecs), key=distance)
 

--- a/tests/test_hamiltonian_qutip.py
+++ b/tests/test_hamiltonian_qutip.py
@@ -1,0 +1,356 @@
+"""
+Tests for qutip-dependent Hamiltonian construction and diagonalization.
+
+Covers the code paths in:
+  pyEPR/calcs/hamiltonian.py   — MatrixOps, HamOps
+  pyEPR/calcs/back_box_numeric.py — black_box_hamiltonian, make_dispersive,
+                                     epr_numerical_diagonalization
+
+All tests use purely synthetic inputs and run without any HFSS connection.
+Designed to catch qutip 4→5 API regressions (e.g. ket.dag()*ket now returns
+a complex scalar in qutip 5, not a 1x1 Qobj).
+"""
+import numpy as np
+import pytest
+
+qutip = pytest.importorskip("qutip", reason="qutip not installed")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FOCK = 6  # small truncation for fast tests
+
+
+def simple_1mode_hamiltonian(fock_trunc=FOCK, freq_hz=5e9, lj_h=10e-9, zpf=0.15):
+    """Return H (Qobj) for a 1-mode, 1-junction system."""
+    from pyEPR.calcs.back_box_numeric import black_box_hamiltonian
+    from pyEPR.calcs.constants import fluxQ
+
+    fs = np.array([freq_hz])
+    ljs = np.array([lj_h])
+    fzpfs = np.array([[zpf * fluxQ]])  # generalized ZPF
+    return black_box_hamiltonian(fs, ljs, fzpfs, cos_trunc=6, fock_trunc=fock_trunc)
+
+
+def simple_2mode_hamiltonian(fock_trunc=FOCK):
+    """Return H (Qobj) for a 2-mode, 1-junction system."""
+    from pyEPR.calcs.back_box_numeric import black_box_hamiltonian
+    from pyEPR.calcs.constants import fluxQ
+
+    fs = np.array([5e9, 6.5e9])
+    ljs = np.array([10e-9])
+    fzpfs = np.array([[0.15 * fluxQ], [0.01 * fluxQ]])
+    return black_box_hamiltonian(fs, ljs, fzpfs, cos_trunc=6, fock_trunc=fock_trunc)
+
+
+# ---------------------------------------------------------------------------
+# MatrixOps
+# ---------------------------------------------------------------------------
+
+class TestMatrixOps:
+    def test_cos_approx_identity_at_zero(self):
+        """cos_approx(0) ≈ identity (missing constant term from Taylor, but
+        Taylor of cos(x) around 0 has leading term 1, which cos_approx omits
+        — it returns only the non-trivial part starting at x^2)."""
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        # Passing a zero operator: result should be a zero Qobj
+        zero_op = qutip.qzero(FOCK)
+        result = MatrixOps.cos_approx(zero_op, cos_trunc=5)
+        # All terms are proportional to zero_op^(2i), so result is zero
+        assert isinstance(result, qutip.Qobj)
+        assert np.allclose(result.full(), 0)
+
+    def test_cos_approx_returns_hermitian(self):
+        """cos_approx of a Hermitian operator should be Hermitian."""
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(FOCK)
+        x = a + a.dag()  # position-like, Hermitian
+        result = MatrixOps.cos_approx(x, cos_trunc=6)
+        assert isinstance(result, qutip.Qobj)
+        diff = (result - result.dag()).norm()
+        assert diff < 1e-10, f"cos_approx result not Hermitian, |H - H†| = {diff}"
+
+    def test_cos_exact_hermitian(self):
+        """MatrixOps.cos of a Hermitian operator should be Hermitian."""
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(FOCK)
+        x = 0.1 * (a + a.dag())
+        result = MatrixOps.cos(x)
+        assert isinstance(result, qutip.Qobj)
+        diff = (result - result.dag()).norm()
+        assert diff < 1e-10
+
+    def test_cos_exact_vs_approx_close_for_small_arg(self):
+        """For small argument, exact cos and Taylor approx should agree.
+
+        cos_approx starts at i=2 (x^4/4! term), intentionally omitting the
+        constant (1) and quadratic (-x^2/2) terms which are handled elsewhere
+        in the Hamiltonian.  The full cosine is 1 - x^2/2 + cos_approx(x).
+        """
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        from pyEPR.toolbox.pythonic import fact
+        a = qutip.destroy(FOCK)
+        x = 0.05 * (a + a.dag())  # small argument
+        exact = MatrixOps.cos(x)
+        # Reconstruct full Taylor series: 1 - x^2/2 + higher terms (cos_approx)
+        full_approx = qutip.qeye(FOCK) - x**2 / float(fact(2)) + MatrixOps.cos_approx(x, cos_trunc=8)
+        diff = (exact - full_approx).norm() / exact.norm()
+        assert diff < 1e-6, f"cos exact vs approx differ by {diff:.2e}"
+
+    def test_dot_product(self):
+        """MatrixOps.dot should sum pairwise products correctly."""
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        n = qutip.num(FOCK)
+        I = qutip.qeye(FOCK)
+        result = MatrixOps.dot([2.0, 3.0], [n, I])
+        expected = 2.0 * n + 3.0 * I
+        assert (result - expected).norm() < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# HamOps — qutip 5 compatibility critical here
+# ---------------------------------------------------------------------------
+
+class TestHamOps:
+    def test_fock_state_on_single_mode(self):
+        """fock_state_on({0:n}) should give |n>."""
+        from pyEPR.calcs.hamiltonian import HamOps
+        ket0 = HamOps.fock_state_on({0: 0}, FOCK, N_modes=1)
+        ket1 = HamOps.fock_state_on({0: 1}, FOCK, N_modes=1)
+        # |0> and |1> should be orthogonal
+        inner = ket0.dag() * ket1
+        val = inner.norm() if hasattr(inner, "norm") else abs(inner)
+        assert val < 1e-12
+
+    def test_fock_state_on_two_mode(self):
+        """|1,0> and |0,1> should be orthogonal; each should have unit norm."""
+        from pyEPR.calcs.hamiltonian import HamOps
+        s10 = HamOps.fock_state_on({0: 1, 1: 0}, FOCK, N_modes=2)
+        s01 = HamOps.fock_state_on({0: 0, 1: 1}, FOCK, N_modes=2)
+        inner = s10.dag() * s01
+        val = inner.norm() if hasattr(inner, "norm") else abs(inner)
+        assert val < 1e-12
+        assert abs(s10.norm() - 1.0) < 1e-12
+        assert abs(s01.norm() - 1.0) < 1e-12
+
+    def test_closest_state_to_exact_eigenstate(self):
+        """Given an exact Fock state as eigenvector, closest_state_to finds it."""
+        from pyEPR.calcs.hamiltonian import HamOps
+        # Simple 1-mode number operator — eigenstates are Fock states
+        n_op = qutip.num(FOCK)
+        evals, evecs = n_op.eigenstates()
+
+        target = qutip.basis(FOCK, 2)  # |2>
+        energy, vec = HamOps.closest_state_to(target, evals, evecs)
+        assert abs(energy - 2.0) < 1e-10, f"Expected energy 2, got {energy}"
+
+    def test_closest_state_to_idx_exact(self):
+        """closest_state_to_idx returns the index of the best-matching eigenstate."""
+        from pyEPR.calcs.hamiltonian import HamOps
+        n_op = qutip.num(FOCK)
+        evals, evecs = n_op.eigenstates()
+
+        target = qutip.basis(FOCK, 3)  # |3>
+        idx, _ = HamOps.closest_state_to_idx(target, evecs)
+        assert idx == 3, f"Expected index 3, got {idx}"
+
+    def test_identify_fock_levels_linear_hamiltonian(self):
+        """For a linear 2-mode Hamiltonian, Fock level assignment should be trivial."""
+        from pyEPR.calcs.hamiltonian import HamOps
+        fock_trunc = 5
+        I = qutip.qeye(fock_trunc)
+        n = qutip.num(fock_trunc)
+        # H = n ⊗ I + I ⊗ n  (equal mode frequencies)
+        H = qutip.tensor(n, I) + qutip.tensor(I, n)
+        _, evecs = H.eigenstates()
+
+        fock_map = HamOps.identify_Fock_levels(fock_trunc, evecs, N_modes=2, Fock_max=3)
+        # Ground state (index of |0,0>) should map to {0:0, 1:0}
+        assert {0: 0, 1: 0} in fock_map.values()
+
+
+# ---------------------------------------------------------------------------
+# black_box_hamiltonian
+# ---------------------------------------------------------------------------
+
+class TestBlackBoxHamiltonian:
+    def test_returns_qobj(self):
+        """black_box_hamiltonian should return a qutip.Qobj."""
+        H = simple_1mode_hamiltonian()
+        assert isinstance(H, qutip.Qobj)
+
+    def test_dimension_1mode(self):
+        """1-mode fock_trunc=6 → H should be 6×6."""
+        H = simple_1mode_hamiltonian(fock_trunc=6)
+        assert H.shape == (6, 6)
+
+    def test_dimension_2mode(self):
+        """2-mode fock_trunc=5 → H should be 25×25."""
+        H = simple_2mode_hamiltonian(fock_trunc=5)
+        assert H.shape == (25, 25)
+
+    def test_hermitian(self):
+        """Hamiltonian must be Hermitian (H = H†)."""
+        H = simple_1mode_hamiltonian()
+        diff = (H - H.dag()).norm()
+        assert diff < 1e-10, f"|H - H†| = {diff:.2e}"
+
+    def test_hermitian_2mode(self):
+        """2-mode Hamiltonian must be Hermitian."""
+        H = simple_2mode_hamiltonian()
+        diff = (H - H.dag()).norm()
+        assert diff < 1e-10
+
+    def test_eigenvalues_real(self):
+        """All eigenvalues of a Hermitian operator should be real."""
+        H = simple_1mode_hamiltonian()
+        evals = H.eigenenergies()
+        assert np.allclose(evals.imag, 0, atol=1e-10), "Eigenvalues have imaginary part"
+
+    def test_ground_state_minimal(self):
+        """Ground state energy should be the minimum eigenvalue."""
+        H = simple_1mode_hamiltonian()
+        evals = H.eigenenergies()
+        assert evals[0] == pytest.approx(min(evals), rel=1e-10)
+
+    def test_individual_mode_returns_tuple(self):
+        """individual=True should return (H_lin, H_nl) tuple."""
+        from pyEPR.calcs.back_box_numeric import black_box_hamiltonian
+        from pyEPR.calcs.constants import fluxQ
+        fs = np.array([5e9])
+        ljs = np.array([10e-9])
+        fzpfs = np.array([[0.15 * fluxQ]])
+        result = black_box_hamiltonian(fs, ljs, fzpfs, individual=True)
+        assert isinstance(result, tuple) and len(result) == 2
+        H_lin, H_nl = result
+        assert isinstance(H_lin, qutip.Qobj)
+        assert isinstance(H_nl, qutip.Qobj)
+
+    def test_nan_in_fzpfs_raises(self):
+        """NaN in fzpfs should raise AssertionError."""
+        from pyEPR.calcs.back_box_numeric import black_box_hamiltonian
+        from pyEPR.calcs.constants import fluxQ
+        fzpfs = np.array([[np.nan * fluxQ]])
+        with pytest.raises(AssertionError):
+            black_box_hamiltonian(np.array([5e9]), np.array([10e-9]), fzpfs)
+
+
+# ---------------------------------------------------------------------------
+# make_dispersive
+# ---------------------------------------------------------------------------
+
+class TestMakeDispersive:
+    def test_output_shapes_1mode(self):
+        """make_dispersive: 1-mode system → f1s shape (1,), chis shape (1,1)."""
+        from pyEPR.calcs.back_box_numeric import black_box_hamiltonian, make_dispersive
+        from pyEPR.calcs.constants import fluxQ
+        H = simple_1mode_hamiltonian()
+        phi_zpf = np.array([[0.15]])
+        f0s = np.array([5.0])
+        f1s, chis, _, _ = make_dispersive(H, fock_trunc=FOCK, fzpfs=phi_zpf, f0s=f0s)
+        assert f1s.shape == (1,)
+        assert np.array(chis).shape == (1, 1)
+
+    def test_output_shapes_2mode(self):
+        """make_dispersive: 2-mode system → f1s shape (2,), chis shape (2,2)."""
+        from pyEPR.calcs.back_box_numeric import make_dispersive
+        H = simple_2mode_hamiltonian(fock_trunc=FOCK)
+        phi_zpf = np.array([[0.15], [0.01]])
+        f0s = np.array([5.0, 6.5])
+        f1s, chis, _, _ = make_dispersive(H, fock_trunc=FOCK, fzpfs=phi_zpf, f0s=f0s)
+        assert f1s.shape == (2,)
+        assert np.array(chis).shape == (2, 2)
+
+    def test_chi_matrix_symmetric(self):
+        """Cross-Kerr matrix should be symmetric."""
+        from pyEPR.calcs.back_box_numeric import make_dispersive
+        H = simple_2mode_hamiltonian(fock_trunc=FOCK)
+        phi_zpf = np.array([[0.15], [0.01]])
+        f0s = np.array([5.0, 6.5])
+        _, chis, _, _ = make_dispersive(H, fock_trunc=FOCK, fzpfs=phi_zpf, f0s=f0s)
+        chis = np.array(chis)
+        assert np.isclose(chis[0, 1].real, chis[1, 0].real, rtol=1e-6)
+
+    def test_accepts_list_input(self):
+        """make_dispersive should accept [H_lin, H_nl] list (individual=True path)."""
+        from pyEPR.calcs.back_box_numeric import black_box_hamiltonian, make_dispersive
+        from pyEPR.calcs.constants import fluxQ
+        fs = np.array([5e9])
+        ljs = np.array([10e-9])
+        fzpfs = np.array([[0.15 * fluxQ]])
+        # Must use the same fock_trunc in both calls so dimensions match
+        H_list = black_box_hamiltonian(fs, ljs, fzpfs, fock_trunc=FOCK, individual=True)
+        phi_zpf = np.array([[0.15]])
+        f0s = np.array([5.0])
+        # Should not raise
+        f1s, chis, _, _ = make_dispersive(H_list, fock_trunc=FOCK, fzpfs=phi_zpf, f0s=f0s)
+        assert f1s.shape == (1,)
+
+    def test_rejects_non_qobj(self):
+        """Passing a numpy array should raise TypeError."""
+        from pyEPR.calcs.back_box_numeric import make_dispersive
+        with pytest.raises(TypeError):
+            make_dispersive(np.eye(FOCK), fock_trunc=FOCK)
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline: epr_numerical_diagonalization
+# ---------------------------------------------------------------------------
+
+class TestEprNumericalDiagonalizationFull:
+    def test_return_H_flag(self):
+        """return_H=True should return (f_ND, chi_ND, H) triple."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        result = epr_numerical_diagonalization(
+            np.array([5.0]), np.array([10e-9]), np.array([[0.15]]),
+            cos_trunc=6, fock_trunc=FOCK, return_H=True
+        )
+        assert len(result) == 3
+        f_ND, chi_ND, H = result
+        assert isinstance(H, qutip.Qobj)
+
+    def test_custom_nonlinear_potential(self):
+        """Passing a custom non_linear_potential should run without error."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        from pyEPR.calcs.hamiltonian import MatrixOps
+
+        def quartic(x):
+            return x**4 / 24.0  # trivial test potential
+
+        f_ND, chi_ND = epr_numerical_diagonalization(
+            np.array([5.0]), np.array([10e-9]), np.array([[0.15]]),
+            cos_trunc=6, fock_trunc=FOCK,
+            non_linear_potential=quartic
+        )
+        assert f_ND.shape == (1,)
+
+    def test_physical_transmon_anharmonicity_sign(self):
+        """
+        Transmon anharmonicity should be positive in pyEPR sign convention
+        (down-shift = positive value in chi_ND diagonal).
+        Verified for a range of physically reasonable ZPF values.
+        """
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        for zpf in [0.10, 0.15, 0.20]:
+            _, chi_ND = epr_numerical_diagonalization(
+                np.array([5.0]), np.array([10e-9]), np.array([[zpf]]),
+                cos_trunc=8, fock_trunc=9
+            )
+            assert chi_ND[0, 0].real > 0, (
+                f"Anharmonicity should be positive for zpf={zpf}, got {chi_ND[0,0].real}"
+            )
+
+    def test_larger_zpf_gives_larger_anharmonicity(self):
+        """Larger ZPF → stronger coupling → larger anharmonicity."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        _, chi_small = epr_numerical_diagonalization(
+            np.array([5.0]), np.array([10e-9]), np.array([[0.05]]),
+            cos_trunc=8, fock_trunc=9
+        )
+        _, chi_large = epr_numerical_diagonalization(
+            np.array([5.0]), np.array([10e-9]), np.array([[0.20]]),
+            cos_trunc=8, fock_trunc=9
+        )
+        assert chi_large[0, 0].real > chi_small[0, 0].real


### PR DESCRIPTION
## Summary

- Fixes two silent runtime breakages introduced by the qutip 4→5 API change
- Adds 28 new tests covering the full numerical diagonalization pipeline
- Updates the PyPI publish workflow to modern tooling

---

## qutip 5.x compatibility fixes

In qutip 5, `ket.dag() * ket` returns a `complex` scalar instead of a 1×1 `Qobj`, so calling `.norm()` or `.full()[0,0]` on the result raises `AttributeError` at runtime.

**`pyEPR/calcs/hamiltonian.py`** — `HamOps.closest_state_to` and `closest_state_to_idx`:
```python
# Before (breaks on qutip 5):
return inner.norm()
# After (works on both 4 and 5):
return inner.norm() if hasattr(inner, "norm") else abs(inner)
```

**`pyEPR/calcs/back_box_numeric.py`** — `get_expect_number` and matrix element in the deprecated `use_1st_order=True` path:
```python
# Before:
return result.full()[0, 0]
# After:
return result.full()[0, 0] if hasattr(result, "full") else complex(result)
```

Also fixed `make_dispersive`'s Hamiltonian type-detection from `hasattr(H, "__len__")` (which incorrectly matches numpy arrays and qutip Qobjs) to `isinstance(H, (list, tuple))`, so passing a numpy array now correctly raises `TypeError` instead of a confusing `ValueError`.

## New tests — `tests/test_hamiltonian_qutip.py` (28 tests)

| Class | What's tested |
|---|---|
| `TestMatrixOps` | `cos_approx` structure/Hermiticity, exact vs Taylor, dot product |
| `TestHamOps` | `fock_state_on` (1- and 2-mode), `closest_state_to`, `identify_Fock_levels` |
| `TestBlackBoxHamiltonian` | Returns Qobj, correct dims, Hermitian, real eigenvalues, NaN guard, individual-mode tuple |
| `TestMakeDispersive` | Output shapes, chi symmetry, `[H_lin, H_nl]` list input, numpy array rejection |
| `TestEprNumericalDiagonalizationFull` | `return_H` flag, custom potential, anharmonicity sign, ZPF scaling |

All 28 pass. Full suite: 47 passed, 7 deselected (hfss marker).

## Publish workflow update

`publish-to-pypi.yml` was using Python 3.7 and floating `@master` pins. Updated to:
- Python 3.12
- `actions/checkout@v4`, `actions/setup-python@v5`
- `pypa/gh-action-pypi-publish@v1.12.4` (pinned)
- Secret name updated to `PYPI_API_TOKEN` (standard name — rename the secret in repo Settings → Secrets if it was previously called `pypi_password`)

## Docs (ReadTheDocs)

The `.readthedocs.yml` fix landed in PR #173. The docs page at https://pyepr-docs.readthedocs.io is returning 403 — the project may be set to **private** on ReadTheDocs. To fix: log into readthedocs.org, go to the pyepr-docs project → Admin → Settings, and set **Privacy Level** to Public.

---

*Prepared with Claude Code.*

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_