### PR TITLE
CI: opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ env:
   # Increment this to invalidate the cache without modifying requirements.txt
   PIPCACHEVERSION: 0
   PYTHONVERSION: '3.9.x'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   pylint:


### PR DESCRIPTION
Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the CI workflow env, silencing the Node.js 20 deprecation warnings on `actions/checkout`, `actions/cache`, `actions/setup-python`, and `actions/upload-artifact`.

Node.js 20 will be forcibly removed from runners on 2026-09-16 — this opts in now while it's still voluntary.

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_