### PR TITLE
Fix pyproject.toml license deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyEPR-quantum"
 dynamic = ["version"]
 description = "Python Energy-Participation-Ratio (EPR) package for quantum chip design"
 readme = { file = "README.md", content-type = "text/markdown" }
-license = { text = "BSD-3-Clause" }
+license = "BSD-3-Clause"
 authors = [
     { name = "Zlatko K. Minev", email = "zlatko.minev@aya.yale.edu" },
 ]
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Environment :: Console",
-    "License :: OSI Approved :: BSD License",
 ]
 dependencies = [
     "addict",


### PR DESCRIPTION
Fixes two `SetuptoolsDeprecationWarning` messages appearing during the PyPI build:

- `license = { text = "BSD-3-Clause" }` → `license = "BSD-3-Clause"` (SPDX string format per PEP 639)
- Removed `"License :: OSI Approved :: BSD License"` classifier (redundant with SPDX expression)

Builds will break without this change by 2027-02-18.

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_