### PR TITLE
docs: modernize installation guide, landing page, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,10 @@ Welcome to pyEPR :beers:! &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;(see [arXiv:2010.00620](
 
 # Start here: Using `pyEPR`
 
-1. **Fork**  :fork_and_knife: the [``pyEPR top-level repository`` ](https://github.com/zlatko-minev/pyEPR) on GitHub. ([How to fork a GitHub repo?](https://help.github.com/en/articles/fork-a-repo)). Share some love by **staring** :star: [pyEPR](https://github.com/zlatko-minev/pyEPR/).
-2. **Clone** :point_down: your forked repository locally. ([How to clone a GitHub repo?](https://help.github.com/en/articles/cloning-a-repository)). Setup the `pyEPR` python code by following [Installation and Python Setup](#installation-of-pyepr).
-3. **Tutorials**  Learn how to use using the [jupyter notebook tutorials](https://github.com/zlatko-minev/pyEPR/tree/master/_tutorial_notebooks)
-4. **Stay up to date** Enjoy and make sure to git add the master remote branch  `git remote add MASTER_MINEV git://github.com/zlatko-minev/pyEPR.git` [(help?)](https://stackoverflow.com/questions/11266478/git-add-remote-branch).
-5. **Cite `pyEPR`**  [arXiv:2010.00620](https://arxiv.org/abs/2010.00620) / [arXiv:1902.10355](https://arxiv.org/abs/1902.10355)  and enjoy! :birthday:  [![DOI](https://zenodo.org/badge/101073856.svg)](https://zenodo.org/badge/latestdoi/101073856)
+1. **Install** — see [Installation and setup](#installation-and-setup-of-pyepr) below. The fastest path: `pip install pyEPR-quantum`.
+2. **Tutorials** — work through the [Jupyter notebook tutorials](https://github.com/zlatko-minev/pyEPR/tree/master/_tutorial_notebooks) to learn the full workflow.
+3. **Read the docs** — [pyepr-docs.readthedocs.io](https://pyepr-docs.readthedocs.io) for the API reference and detailed guides.
+4. **Cite `pyEPR`** — [arXiv:2010.00620](https://arxiv.org/abs/2010.00620) / [arXiv:1902.10355](https://arxiv.org/abs/1902.10355) [![DOI](https://zenodo.org/badge/101073856.svg)](https://zenodo.org/badge/latestdoi/101073856)
 
 
 
@@ -163,55 +162,63 @@ epra.quick_plot_mode(0,0,1,numeric=True, swp_variable=swp_variable)
 
 # Installation and setup of `pyEPR`
 -------------
-Use `pyEPR` directly from the source, and pull updates from the master git repo, since we often update it. The following steps explain how to set up Python 3, fork the `pyEPR` repo and use it.
-Please keep up to date with `pyEPR` by using git. We like to make it simple using a git-gui manager, [SourceTree](sourcetree.com) or [GitHub Desktop](https://desktop.github.com/).
 
-**Quick setup**
-We recommend the approach in the following section, which will be most up to date, but for quick use you can use the [conda forge channel](https://anaconda.org/conda-forge/pyepr-quantum) to install
+**Requires Python 3.9–3.12.**  All dependencies are installed automatically.
+
+### Quick install
+
+**uv** (recommended — fast, modern):
+```sh
+uv pip install pyEPR-quantum
 ```
-conda install -c conda-forge pyepr-quantum
-```
-or the [PyPi](https://pypi.org/project/pyEPR-quantum/0.8/) channel
-```
+
+**pip**:
+```sh
 pip install pyEPR-quantum
 ```
 
-**Recommended procedure.**   <br />
-
- 1. Install Python 3.x, we recommend the [Anaconda](https://www.anaconda.com/distribution/#download-section) distribution. <br>
- The code is currently under dev with Python 3.6/7. It was developed under 2.7 and should still be compatible. <br>
-  After the install, make sure you configure your system PATH variables. On Windows, in the taskbar search or control panel, search for ["Edit environment variables for your account"](https://superuser.com/questions/949560/how-do-i-set-system-environment-variables-in-windows-10). In the section System Variables, find the PATH environment variable and select it. Click Edit.  Place`C:\Anaconda3;C:\Anaconda3\Scripts;C:\Anaconda3\Library\bin;` at the beginning of the path. If you have a previous Python installation this step is *very* important, especially to compile the qutip module. You may verity your path using the following command in the Command Prompt (terminal):
-      `sh
-      $ echo %PATH%
-      `
-
- 2. Install the required packages, including [pint](http://pint.readthedocs.io/en/latest/), [qutip](http://qutip.org/), and [addict](https://github.com/mewwts/addict). In a terminal window
- ```sh
- conda install -c conda-forge pint
- conda install -c conda-forge qutip
- pip install addict
- ```
- 3. Fork this pyEPR repository on GitHub with your GitHub account. You may clone the fork to your PC and manage it using the [SourceTree](https://www.sourcetreeapp.com/) git-gui manager.
- 4. Add the pyEPR repository folder to your python search path. Make sure to add the git remote to the master is set up,  `git remote add MASTER_MINEV git://github.com/zlatko-minev/pyEPR.git`!  [(Help?)](https://stackoverflow.com/questions/11266478/git-add-remote-branch)
- 5. Edit pyEPR module `_config_user.py`  to set your data-saving directory and other parameters of interest.  (To keep your changes local, use the shell command `git update-index --skip-worktree _config_user.py` in the `pyEPR/pyEPR` folder)
- 6. **ENJOY and cite pyEPR!**  :+1:
-
-#### “Editable” install for development mode
-Although not required, it’s common to locally install your project in “editable” or “develop” mode while you’re working on it. This allows your project to be both installed and editable in project form.
-
-Assuming you’re in the root of your project directory, then run [(see here)](https://packaging.python.org/guides/distributing-packages-using-setuptools/#working-in-development-mode):
+**conda** (conda-forge channel):
+```sh
+conda install -c conda-forge pyepr-quantum
 ```
-   python -m pip install -e .
+
+> The conda-forge package name is `pyepr-quantum` (lower-case); the PyPI name is `pyEPR-quantum`.
+> Either way you import it as `import pyEPR as epr`.
+
+### Development / editable install
+
+```sh
+git clone https://github.com/zlatko-minev/pyEPR.git
+cd pyEPR
+pip install -e “.[test]”
+pytest          # runs all tests that don’t need a live HFSS session
 ```
-Although somewhat cryptic, -e is short for --editable, and . refers to the current working directory, so together, it means to install the current directory (i.e. your project) in editable mode. This will also install any dependencies declared with “install_requires” and any scripts declared with “console_scripts”. Dependencies will be installed in the usual, non-editable mode. Quoted from [python](https://packaging.python.org/guides/distributing-packages-using-setuptools/#working-in-development-mode)
 
-#### Note for Mac/Linux.
-Follow the same instructions above. You shouldn't have to install mingw or modify distutils.cfg, since your distribution should come with gcc as the default compiler.
+### Platform support
 
+pyEPR has two layers with different platform requirements:
 
+| Feature | Windows | macOS | Linux |
+|---|---|---|---|
+| EPR / quantum analysis (`DistributedAnalysis`, `QuantumAnalysis`) | ✅ | ✅ | ✅ |
+| Ansys HFSS COM interface (`HfssDesign`, `ansys.py`) | ✅ | ⚠️ limited | ⚠️ limited |
+
+**EPR and quantum analysis** are pure-Python and work on all platforms — no Ansys installation required for post-processing.
+
+**The HFSS COM interface** (`ansys.py`) was written for Windows, where HFSS exposes automation via `pythoncom`/`win32com`.  On macOS/Linux you can still reach a remote Windows HFSS instance over a network COM bridge.
+
+> **Note on PyAEDT:** [PyAEDT](https://github.com/ansys/pyaedt) is Ansys’s official cross-platform Python scripting library for AEDT.  pyEPR predates it and focuses on the quantum EPR quantization workflow that PyAEDT does not cover.  They are complementary: use PyAEDT for geometry/mesh/solve scripting, pyEPR for EPR-based Hamiltonian extraction.
+
+### Optional configuration
+
+Edit `pyEPR/_config_user.py` to set your data-save directory and logging level.
+To keep local changes out of git:
+```sh
+git update-index --skip-worktree pyEPR/_config_user.py
+```
 
 #### Legacy users
-Warning: pyEPR organization was significantly improved in v0.8-dev (starting 2020; current branch: master \[to be made stable soon\]). If you used a previous version, you will find that all key classes have been renamed. Please, see the tutorials and docs.  In the meantime, if you cannot switch yet, revert to use the stable v0.7.
+pyEPR was significantly refactored in v0.8 (2020). Key classes were renamed — see the tutorials and docs. If you cannot upgrade yet, use the stable v0.7 tag.
 
 
 # HFSS Project Setup for `pyEPR`
@@ -256,33 +263,12 @@ conda update qutip
 conda update numpy
 ```
 
-###### Qutip installation
-You may also choose to install the optional qutip package for some advanced numerical analysis of the Hamiltonian.
-We use [Qutip](http://qutip.org/) to handle quantum objects. Follow the instruction on their website. As of Aug. 2017, qutip is part of conda, and you can use
+###### QuTiP installation
+QuTiP is a required dependency and is installed automatically with `pip install pyEPR-quantum`.
+If you need to install it separately:
 ```sh
-conda install qutip
-```
-If this doesn't work, try  installing from conda forge
-```sh
-conda install -c conda-forge qutip
-```
-######  Qutip installation -- alternative, manual install
-If you wish to install manually, follow the following procedure. Some of this can get a bit tricky at times.
-First, you need to install a C compiler, since qutip uses Cython. If you dont have VS9, gcc, or mingw installed, the following works:
-```sh
-pip install -i https://pypi.anaconda.org/carlkl/simple mingwpy
-```
-Let anaconda know to use this compiler by creating the file `C:\Anaconda2\Lib\distutils\distutils.cfg` with the following content
-```
-[build]
-compiler = mingw32
-[build_ext]
-compiler = mingw32
-```
-Next, let's install qutip. You can choose to use conda install or pip install, or pull from the git directly  as done here:
-```sh
-conda install git
-pip install git+https://github.com/qutip/qutip.git
+pip install qutip          # PyPI (qutip >= 5.0 required)
+conda install -c conda-forge qutip   # conda-forge
 ```
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.mathjax",
     "sphinx_rtd_theme",
+    "sphinx_tabs.tabs",
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
     "matplotlib.sphinxext.plot_directive",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,43 +1,117 @@
-.. pyEPR documentation master file, created by
-   sphinx-quickstart on Wed Jan 15 05:35:04 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.  | **Date**: |today|
+.. pyEPR documentation master file
 
 *********************************************
-Welcome to pyEPR 🍻!
+pyEPR — Energy-Participation-Ratio Framework
 *********************************************
 
-Powerful, automated analysis and design of quantum microwave devices
-***************************************************************************
-**Version**: |version|
-
+**Version**: |version| | **License**: BSD-3-Clause | `GitHub <https://github.com/zlatko-minev/pyEPR>`_ | `PyPI <https://pypi.org/project/pyEPR-quantum/>`_
 
 .. image:: _static/read_me_0.png
    :width: 100%
-   :alt: pyEPR
+   :alt: pyEPR overview
    :align: center
 
-**pyEPR** is an open source, BSD-licensed library providing high-efficiency,
-easy-to-use analysis functions and automation for the design of quantum chips based on superconducting quantum  circuits, both distributed and lumped.
-pyEPR interfaces the classical distributed microwave analysis with that of quantum structures and Hamiltonians.
-It is chiefly based on the `energy participation ratio <https://arxiv.org/abs/1902.10355>`_ approach; however, it has since v0.4 extended to cover a broad range of
-design approaches. pyEPR stradels the analysis from Maxwell's to Schrodinger's equations, and converts the solutions of distributed microwave (typically eigenmode simulations)
-to a fully diagonalized spectrum of the energy levels, couplings, and key parameters of a many-body quantum Hamiltonian.
+----
 
-pyEPR contains both analytic and numeric solutions.
+**pyEPR** is an open-source Python library for the automated design and
+quantization of Josephson quantum circuits.  It bridges classical distributed
+microwave simulation (Ansys HFSS) and quantum circuit Hamiltonians using the
+`energy-participation ratio (EPR) <https://arxiv.org/abs/2010.00620>`_ method.
+
+What pyEPR does
+===============
+
+pyEPR has two main layers:
+
+1. **EPR / quantum analysis** *(platform-independent)*
+   Extracts energy-participation ratios from HFSS eigenmode field solutions,
+   then performs numerical diagonalization (via `QuTiP <https://qutip.org>`_)
+   to yield qubit frequencies, anharmonicities, dispersive shifts (χ), and
+   cross-Kerr couplings — all in one automated pipeline.
+
+2. **Ansys HFSS COM interface** *(Windows-first; see* :ref:`install-platform` *)*
+   A Python wrapper around the HFSS COM/DCOM automation API.  Controls
+   simulation setup, field extraction, and optimetric sweeps directly from
+   Python.  Originally written before `PyAEDT <https://github.com/ansys/pyaedt>`_
+   existed; the two tools are complementary — pyEPR for quantum EPR analysis,
+   PyAEDT for general AEDT scripting.
+
+Quick install
+=============
+
+.. tabs::
+
+   .. tab:: uv *(recommended)*
+
+      .. code-block:: bash
+
+         uv pip install pyEPR-quantum
+
+   .. tab:: pip
+
+      .. code-block:: bash
+
+         pip install pyEPR-quantum
+
+   .. tab:: conda
+
+      .. code-block:: bash
+
+         conda install -c conda-forge pyepr-quantum
+
+See :ref:`install` for full instructions including development installs,
+platform notes, and Ansys version compatibility.
+
+Quick-start example
+===================
+
+The following script connects to HFSS, extracts EPR data, and produces the
+full Hamiltonian for a two-qubit / one-cavity chip in a few lines of code.
+
+.. code-block:: python
+
+   import pyEPR as epr
+
+   # 1. Connect to HFSS project
+   pinfo = epr.ProjectInfo(
+       project_path = r'C:\sim_folder',
+       project_name = r'cavity_with_two_qubits',
+       design_name  = r'Alice_Bob',
+   )
+
+   # 2. Specify Josephson junctions
+   pinfo.junctions['jAlice'] = {
+       'Lj_variable': 'Lj_alice', 'rect': 'rect_alice',
+       'line': 'line_alice', 'Cj_variable': 'Cj_alice',
+   }
+   pinfo.junctions['jBob'] = {
+       'Lj_variable': 'Lj_bob', 'rect': 'rect_bob',
+       'line': 'line_bob', 'Cj_variable': 'Cj_bob',
+   }
+   pinfo.validate_junction_info()
+
+   # 3. Run EPR field extraction
+   eprd = epr.DistributedAnalysis(pinfo)
+   eprd.do_EPR_analysis()
+
+   # 4. Quantum Hamiltonian diagonalization
+   epra = epr.QuantumAnalysis(eprd.data_filename)
+   epra.analyze_all_variations(cos_trunc=8, fock_trunc=7)
+   epra.plot_hamiltonian_results(swp_variable='Lj_alice')
+
+See the `Jupyter notebook tutorials
+<https://github.com/zlatko-minev/pyEPR/tree/master/_tutorial_notebooks>`_
+for step-by-step walkthroughs.
 
 
 .. image:: _static/xmon-example.gif
-   :width: 75%
-   :alt: pyEPR
+   :width: 70%
+   :alt: Xmon example
    :align: center
 
 
-
 Contents
-==================
-
-.. :caption: Contents:
+========
 
 .. toctree::
    :maxdepth: 2
@@ -55,11 +129,9 @@ Contents
    api/*
 
 
-
 Indices and tables
 ==================
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,89 +4,176 @@
 Installation
 **************
 
+.. contents:: On this page
+   :local:
+   :depth: 2
 
-.. _install-main:
+Requirements
+============
 
-Main installation method
-===========================
+- **Python** 3.9 – 3.12
+- **Operating system:** Windows, macOS, or Linux — see `Platform notes`_ below.
 
-1. **Fork** 🍴 the ```pyEPR top-level repository```_ on
-   GitHub. (`How to fork a GitHub repo?`_). Share some love by
-   **staring** :star: `pyEPR`_.
-2. **Clone** 👇 your forked repository locally. (`How to clone
-   a GitHub repo?`_). Setup the ``pyEPR`` python code by following
-   `Installation and Python Setup`_.
-3. **Tutorials** Learn how to use using the `jupyter notebook
-   tutorials`_
-4. **Stay up to date** Enjoy and make sure to git add the master remote
-   branch
-   ``git remote add MASTER_MINEV git://github.com/zlatko-minev/pyEPR.git``
-   `(help?)`_.
-5. **Cite ``pyEPR``** `arXiv:2010.00620 <https://arxiv.org/abs/2010.00620>`_ and `arXiv:1902.10355 <https://arxiv.org/abs/1902.10355>`_ enjoy!  🎂
+.. _install-quick:
 
+Quick install
+=============
 
-.. _``pyEPR top-level repository``: https://github.com/zlatko-minev/pyEPR
-.. _How to fork a GitHub repo?: https://help.github.com/en/articles/fork-a-repo
-.. _pyEPR: https://github.com/zlatko-minev/pyEPR/
-.. _How to clone a GitHub repo?: https://help.github.com/en/articles/cloning-a-repository
-.. _Installation and Python Setup: #installation-of-pyepr
-.. _jupyter notebook tutorials: https://github.com/zlatko-minev/pyEPR/tree/master/_tutorial_notebooks
-.. _(help?): https://stackoverflow.com/questions/11266478/git-add-remote-branch
-.. _`arXiv:1902.10355`: https://arxiv.org/abs/1902.10355
+.. tabs::
 
-.. _install-via_pip:
+   .. tab:: uv *(recommended)*
 
-Installing locally via pip
-===============================
+      `uv <https://github.com/astral-sh/uv>`_ is a fast, modern Python package manager.
+      Install it once, then:
 
-In the future, ``pyEPR`` can be installed using the Python package manager `pip <http://www.pip-installer.org/>`_.
+      .. code-block:: bash
 
+         uv pip install pyEPR-quantum
 
-However, for the moment, we recommend a local developer installation, which allows for fast upgrades. We are still in active development.
-Perform the steps in the :ref:`install-main` section.
-What you could do, once you have the local clone git, is to install pyEPR locally. Navigate to the local root folder of the repo.
+      Or, inside a uv project/virtual environment:
 
-First, in bash, upgrade python ``pip``
+      .. code-block:: bash
+
+         uv add pyEPR-quantum
+
+   .. tab:: pip + venv
+
+      .. code-block:: bash
+
+         python -m venv .venv
+         source .venv/bin/activate   # Windows: .venv\Scripts\activate
+         pip install pyEPR-quantum
+
+   .. tab:: conda
+
+      ``pyEPR-quantum`` is available on the ``conda-forge`` channel:
+
+      .. code-block:: bash
+
+         conda create -n pyepr python=3.11
+         conda activate pyepr
+         conda install -c conda-forge pyepr-quantum
+
+      .. note::
+
+         The conda-forge package name is ``pyepr-quantum`` (lower-case).
+         The PyPI name is ``pyEPR-quantum``.  Either way, you import it as
+         ``import pyEPR as epr``.
+
+.. _install-dev:
+
+Development / editable install
+================================
+
+Clone the repository and install in editable mode so that your local changes
+are picked up immediately:
+
+.. tabs::
+
+   .. tab:: uv *(recommended)*
+
+      .. code-block:: bash
+
+         git clone https://github.com/zlatko-minev/pyEPR.git
+         cd pyEPR
+         uv pip install -e ".[test]"
+
+   .. tab:: pip + venv
+
+      .. code-block:: bash
+
+         git clone https://github.com/zlatko-minev/pyEPR.git
+         cd pyEPR
+         python -m venv .venv
+         source .venv/bin/activate   # Windows: .venv\Scripts\activate
+         pip install -e ".[test]"
+
+   .. tab:: conda
+
+      .. code-block:: bash
+
+         git clone https://github.com/zlatko-minev/pyEPR.git
+         cd pyEPR
+         conda create -n pyepr python=3.11
+         conda activate pyepr
+         pip install -e ".[test]"
+
+The ``[test]`` extra installs ``pytest`` and ``pytest-cov``.  Run the test
+suite (no Ansys required):
 
 .. code-block:: bash
 
-    python -m pip install -U pip
+   pytest
 
-Now we can locally install the pyEPR module.
+.. _install-platform:
 
-.. code-block:: bash
+Platform notes
+==============
 
-    python -m pip install -r requirements.txt -e .
+pyEPR has two distinct functional layers with different platform requirements:
 
+.. list-table::
+   :widths: 25 25 25 25
+   :header-rows: 1
 
-.. _install-via_conda:
+   * - Feature
+     - Windows
+     - macOS
+     - Linux
+   * - EPR / quantum analysis
+     - ✅ Full support
+     - ✅ Full support
+     - ✅ Full support
+   * - Ansys HFSS COM interface
+     - ✅ Full support
+     - ⚠️ Limited (see below)
+     - ⚠️ Limited (see below)
 
-Installing via conda
-====================
+**EPR and quantum analysis** (``DistributedAnalysis``, ``QuantumAnalysis``) are
+pure-Python and work identically on all platforms — no Ansys installation
+required for post-processing existing data.
 
-For Python 3.6+, installation via `conda`_ is supported since ``pyEPR`` v.0.8.03, through the ``conda-forge`` channel. You can download and install ``pyEPR`` typing in from bash:
-
-.. code-block:: bash
-
-    conda install -c conda-forge pyepr-quantum
-
-The prefix ``-c conda-forge`` is required to activate the optional ``conda-forge`` channel.
-
-.. _install-via_pypi:
-
-Installing via pip from PyPI
-============================
-
-For Python 3.6+, installation via `PyPI`_ is supported since ``pyEPR`` v.0.8. You can download and install ``pyEPR`` typing in from bash:
-
-.. code-block:: bash
-
-    pip install pyEPR-quantum
+**Ansys HFSS COM interface** (``ansys.py``, ``HfssDesign``, etc.) was originally
+written for Windows, where HFSS exposes a COM/DCOM automation interface via
+``pythoncom`` / ``win32com``.  On macOS and Linux, Ansys ships a non-Windows
+scripting interface (IronPython inside the AEDT product, or the ``ansys-aedt``
+Python API); pyEPR's COM wrapper layer does not use these interfaces directly.
+If you are running HFSS on a remote Windows machine or a Windows VM, you can
+still drive it from macOS/Linux over the network COM bridge.
 
 .. note::
 
-  Note that the name of the recipe on the ``conda-forge`` channel is ``pyepr-quantum``, and on PyPI is ``pyEPR-quantum``, as the name `pyepr` was already taken by another project. This does not change anything in the way the library is imported in Python as documented in the guide and examples.
+   **PyAEDT** — Ansys's official open-source Python library
+   (`github.com/ansys/pyaedt <https://github.com/ansys/pyaedt>`_) — provides
+   a fully cross-platform scripting layer for AEDT.  pyEPR predates PyAEDT
+   by several years and covers the quantum-circuit EPR analysis workflow that
+   PyAEDT does not.  For new workflows that only need simulation control
+   (geometry, mesh, solve) and not EPR quantization, PyAEDT is a natural
+   complement or alternative for the COM layer.
 
-.. _conda: https://anaconda.org/conda-forge/pyepr-quantum
-.. _PyPI: https://pypi.org/project/pyEPR-quantum/0.8/
+.. _install-hfss-version:
 
+Ansys HFSS version compatibility
+=================================
+
+AEDT 2021.2 renamed the strings returned by ``GetSolutionType()``.
+AEDT 2024.1 changed the default design type created by ``InsertDesign``.
+pyEPR ≥ 0.9.2 handles both transparently — always use the latest pyEPR.
+
+For the full technical details see the :ref:`HFSS compatibility section
+<install-hfss-version>` in the developer guide (``CLAUDE.md``).
+
+.. _install-config:
+
+Optional configuration
+======================
+
+After installation, you can customise pyEPR's behaviour by editing
+``pyEPR/_config_user.py``.  The most useful settings are the default
+data-save directory and logging verbosity.
+
+To prevent git from tracking your local config changes:
+
+.. code-block:: bash
+
+   git update-index --skip-worktree pyEPR/_config_user.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ include = ["pyEPR*"]
 docs = [
     "sphinx>=4.0",
     "sphinx-rtd-theme>=0.4.0",
+    "sphinx-tabs>=3.4.0",
 ]
 test = [
     "pytest>=7.0",


### PR DESCRIPTION
## Summary

Modernizes the user-facing documentation and README installation experience.

### Changes

**`docs/source/installation.rst`** — full rewrite
- Tabbed install instructions (uv, pip+venv, conda) using `sphinx-tabs`
- uv listed first as the recommended modern tool
- Platform support table: Windows / macOS / Linux with notes on COM interface limitations
- Note on PyAEDT as a complementary tool
- Dev/editable install section with tabs
- HFSS version compatibility callout
- Optional config section (`_config_user.py`)

**`docs/source/index.rst`** — landing page refresh
- Cleaner intro paragraph
- "Two layers" architecture summary (EPR analysis = platform-independent; COM interface = Windows-first)
- Quick-install tabs block
- Better formatted quick-start code example

**`README.md`** — synchronized with docs
- uv first, then pip, then conda (code blocks, since Markdown has no native tabs)
- Platform support table
- PyAEDT note
- Removed: stale Anaconda PATH instructions, Python 2.7 references, manual QuTiP Cython compile steps
- Simplified "Start here" section

**`pyproject.toml`** — `sphinx-tabs>=3.4.0` added to `[docs]` extras

**`docs/source/conf.py`** — `sphinx_tabs.tabs` added to extensions

### Not in this PR
- Theme update (RTD → modern; deferred to follow-up PR as requested)

## Test plan
- [ ] CI docs build passes (`make html` via `test_docs` job)
- [ ] Tabs render in the built HTML
- [ ] Platform table renders correctly
- [ ] README renders on GitHub

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_