### PR TITLE
docs: hide API reference toctree from landing page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -127,6 +127,7 @@ Contents
 .. toctree::
    :caption: API Reference:
    :glob:
+   :hidden:
 
    api/*
 


### PR DESCRIPTION
One-line fix: add `:hidden:` to the `api/*` toctree directive in `index.rst`.

The API reference pages were expanding as a huge inline list on the landing page. With `:hidden:` they still appear in the left sidebar under "API Reference" — they just no longer clutter the front page.

## Test plan
- [ ] CI `test_docs` passes
- [ ] Landing page no longer shows the long API module list
- [ ] API pages still accessible from sidebar

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_