### PR TITLE
fix: four bug fixes for 0.9.4 (#128, #162, #169, #137)

### DIFF
--- a/pyEPR/calcs/back_box_numeric.py
+++ b/pyEPR/calcs/back_box_numeric.py
@@ -257,7 +257,11 @@ def make_dispersive(
             evalue0 = get_expect_number(vector0, H_lin, vector0)
             vector1 = PT_on_vector(vector0, basis0, H_nl, evalues0, evalue0)
 
-            index = np.argmax([(vector1.dag() * evec).norm() for evec in evecs])
+            # qutip 4: dag()*ket returns 1×1 Qobj with .norm(); qutip 5: returns complex scalar
+            index = np.argmax([
+                abs(r.full()[0, 0]) if hasattr(r, "full") else abs(r)
+                for r in (vector1.dag() * evec for evec in evecs)
+            ])
             return evals[index], evecs[index]
 
     else:

--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -1104,7 +1104,7 @@ class DistributedAnalysis(object):
             self.Ljs = Ljs
             self.Cjs = Cjs
             print(
-                f'\t{j_name:<15} {pmj_ind:>8.6g}{("(+)"if _Smj else "(-)"):>5s}        {pmj_cap:>8.6g}'
+                f'\t{j_name:<15} {pmj_ind:>8.6g}{("(+)"if _Smj > 0 else "(-)"):>5s}        {pmj_cap:>8.6g}'
             )
             # print('\tV_peak=', V_peak)
 

--- a/pyEPR/project_info.py
+++ b/pyEPR/project_info.py
@@ -362,7 +362,15 @@ class ProjectInfo(object):
                         )
                     self.setup_name = setup.name
                 else:
-                    self.setup_name = setup_names[0]
+                    if self.setup_name:
+                        if self.setup_name not in setup_names:
+                            raise ValueError(
+                                f"Setup '{self.setup_name}' not found in design. "
+                                f"Available setups: {setup_names}"
+                            )
+                        # else: keep the user-specified name as-is
+                    else:
+                        self.setup_name = setup_names[0]
 
                 # get the actual setup if there is one
                 self.get_setup(self.setup_name)

--- a/pyEPR/reports.py
+++ b/pyEPR/reports.py
@@ -32,7 +32,8 @@ _style_plot_conv_kw = dict(marker="o", ms=4)
 def plot_convergence_max_df(ax, s, kw={}, color="r"):
     """For a single pass"""
     s.plot(ax=ax, **{**dict(c="r"), **_style_plot_conv_kw, **kw})
-    ax.set_yscale("log")
+    if (s > 0).any():
+        ax.set_yscale("log")
     _style_plot_convergence(ax)
     fig = ax.figure
     fig.text(0.45, 0.95, s.name, ha="center", va="bottom", size="medium", color=color)
@@ -84,8 +85,10 @@ def plot_convergence_maxdf_vs_sol(ax, s, s2, kw={}):
     s.index = s2
     (s).plot(ax=ax, **{**_style_plot_conv_kw, **kw})
     _style_plot_convergence(ax, s.name, xlabel="Solved elements", y_title=True)
-    ax.set_yscale("log")
-    ax.set_xscale("log")
+    if (s > 0).any():
+        ax.set_yscale("log")
+    if (s2 > 0).any():
+        ax.set_xscale("log")
 
 
 # quick and dirty use

--- a/tests/test_bugfixes_094.py
+++ b/tests/test_bugfixes_094.py
@@ -1,0 +1,182 @@
+"""
+Tests for the four bug fixes in 0.9.4:
+  - #128  junction sign always printed as (+)
+  - #162  QuTiP 5.x .norm() on complex scalar in back_box_numeric
+  - #169  setup name ignored / hardcoded to first setup
+  - #137  convergence plot crashes on log-scale with non-positive data
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ── Bug #128 ──────────────────────────────────────────────────────────────────
+
+class TestJunctionSignPrint:
+    """_Smj is always 1 or -1; old code used `if _Smj` (always True)."""
+
+    def test_positive_sign_truthy(self):
+        _Smj = 1
+        result = "(+)" if _Smj > 0 else "(-)"
+        assert result == "(+)"
+
+    def test_negative_sign(self):
+        _Smj = -1
+        result = "(+)" if _Smj > 0 else "(-)"
+        assert result == "(-)"
+
+    def test_old_code_was_wrong(self):
+        # Demonstrate the old bug: both 1 and -1 are truthy
+        _Smj = -1
+        old_result = "(+)" if _Smj else "(-)"
+        assert old_result == "(+)", "Old code always returned (+) — this confirms the bug"
+
+    def test_new_code_is_correct(self):
+        for smj, expected in [(1, "(+)"), (-1, "(-)"), (1, "(+)")]:
+            assert ("(+)" if smj > 0 else "(-)" ) == expected
+
+
+# ── Bug #162 ──────────────────────────────────────────────────────────────────
+
+class TestQutip5InnerProduct:
+    """
+    In QuTiP 5, ket.dag() * ket returns a complex scalar, not a 1x1 Qobj.
+    The fixed code uses: abs(r.full()[0,0]) if hasattr(r, 'full') else abs(r)
+    """
+
+    def test_complex_scalar_path(self):
+        # Simulate what QuTiP 5 returns: a plain complex number
+        r = complex(0.6, 0.8)  # |r| = 1.0
+        result = abs(r.full()[0, 0]) if hasattr(r, "full") else abs(r)
+        assert pytest.approx(result, abs=1e-10) == 1.0
+
+    def test_complex_scalar_negative_real(self):
+        r = complex(-0.8, 0.6)
+        result = abs(r.full()[0, 0]) if hasattr(r, "full") else abs(r)
+        assert pytest.approx(result, abs=1e-10) == 1.0
+
+    def test_real_scalar(self):
+        r = 0.5
+        result = abs(r.full()[0, 0]) if hasattr(r, "full") else abs(r)
+        assert pytest.approx(result) == 0.5
+
+    def test_argmax_selects_correct_index(self):
+        # Simulate a list of inner products (complex scalars as QuTiP 5 returns)
+        values = [complex(0.1, 0), complex(0.9, 0), complex(0.3, 0)]
+        index = np.argmax([
+            abs(r.full()[0, 0]) if hasattr(r, "full") else abs(r)
+            for r in values
+        ])
+        assert index == 1  # 0.9 is largest
+
+
+# ── Bug #169 ──────────────────────────────────────────────────────────────────
+
+class TestSetupNameSelection:
+    """
+    The setup-name logic (extracted from ProjectInfo._configure_ansys_project):
+      - if user specified a name that IS in the list: keep it
+      - if user specified a name NOT in the list: raise ValueError
+      - if user specified nothing: pick setup_names[0]
+    """
+
+    @staticmethod
+    def _resolve_setup_name(user_specified, setup_names):
+        """Mirrors the fixed logic in project_info.py."""
+        setup_name = user_specified
+        if setup_name:
+            if setup_name not in setup_names:
+                raise ValueError(
+                    f"Setup '{setup_name}' not found in design. "
+                    f"Available setups: {setup_names}"
+                )
+            # else keep user_specified
+        else:
+            setup_name = setup_names[0]
+        return setup_name
+
+    def test_user_specified_valid_name_is_kept(self):
+        result = self._resolve_setup_name("MySetup", ["DefaultSetup", "MySetup"])
+        assert result == "MySetup"
+
+    def test_no_user_name_falls_back_to_first(self):
+        result = self._resolve_setup_name(None, ["DefaultSetup", "MySetup"])
+        assert result == "DefaultSetup"
+
+    def test_invalid_name_raises_value_error(self):
+        with pytest.raises(ValueError, match="not found"):
+            self._resolve_setup_name("NonExistent", ["DefaultSetup", "MySetup"])
+
+    def test_old_behaviour_always_used_first(self):
+        # Old code: self.setup_name = setup_names[0]  — always overwrote user input
+        user = "MySetup"
+        setup_names = ["DefaultSetup", "MySetup"]
+        old_result = setup_names[0]  # old code always did this
+        assert old_result == "DefaultSetup"  # confirms old bug
+        # New code preserves user intent:
+        new_result = self._resolve_setup_name(user, setup_names)
+        assert new_result == "MySetup"
+
+    def test_empty_string_treated_as_not_specified(self):
+        # Empty string is falsy — should fall back to first setup
+        result = self._resolve_setup_name("", ["DefaultSetup"])
+        assert result == "DefaultSetup"
+
+
+# ── Bug #137 / #164 ──────────────────────────────────────────────────────────
+
+class TestConvergencePlotLogScale:
+    """
+    plot_convergence_max_df and plot_convergence_maxdf_vs_sol called
+    set_yscale("log") unconditionally. If delta-F data has no positive values
+    matplotlib raises ValueError. Fixed by guarding with (s > 0).any().
+    """
+
+    def test_positive_data_uses_log(self):
+        s = pd.Series([0.5, 0.3, 0.1])
+        assert (s > 0).any()
+
+    def test_all_zero_data_skips_log(self):
+        s = pd.Series([0.0, 0.0, 0.0])
+        assert not (s > 0).any()
+
+    def test_negative_data_skips_log(self):
+        s = pd.Series([-0.1, -0.2])
+        assert not (s > 0).any()
+
+    def test_mixed_data_with_positives_uses_log(self):
+        s = pd.Series([0.0, 0.1, 0.3])
+        assert (s > 0).any()
+
+    def test_matplotlib_does_not_crash_with_zero_data(self):
+        """Full integration: matplotlib should not raise with zero delta-F data."""
+        import matplotlib
+        matplotlib.use("Agg")  # non-interactive backend
+        import matplotlib.pyplot as plt
+        from pyEPR.reports import plot_convergence_max_df
+
+        s = pd.Series([0.0, 0.0], name="Max Delta Freq")
+        fig, ax = plt.subplots()
+        try:
+            plot_convergence_max_df(ax, s)
+            fig.tight_layout()   # this is what crashed before
+        except ValueError as e:
+            pytest.fail(f"plot_convergence_max_df raised ValueError: {e}")
+        finally:
+            plt.close(fig)
+
+    def test_matplotlib_does_not_crash_with_positive_data(self):
+        """Ensure normal data still works (log scale applied)."""
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from pyEPR.reports import plot_convergence_max_df
+
+        s = pd.Series([0.5, 0.3, 0.1], name="Max Delta Freq")
+        fig, ax = plt.subplots()
+        try:
+            plot_convergence_max_df(ax, s)
+            fig.tight_layout()
+            assert ax.get_yscale() == "log"
+        finally:
+            plt.close(fig)


### PR DESCRIPTION
Four targeted bug fixes for the 0.9.4 release. Each fix was red-teamed against the actual code before implementation, and each has dedicated tests that run without a live HFSS session.

## Fixes

### #128 — Junction sign always printed as `(+)`
`_Smj` is always `1` or `-1` (both truthy), so `if _Smj` was always `True`. Changed to `if _Smj > 0`. Purely cosmetic — the sign is used correctly in calculations via `Sj["s_" + j_name]`; only the print statement was wrong.

### #162 — QuTiP 5.x `.norm()` crash in `back_box_numeric.py`
In QuTiP 5, `ket.dag() * ket` returns a complex scalar, not a 1×1 Qobj, so `.norm()` fails. The `else`-branch `distance()` was already fixed (uses `np.abs`). Fixed line 260 in the PT branch using the same `hasattr(r, "full")` guard already applied at line 246.

### #169 — `ProjectInfo` setup name ignored
When the user passes `setup_name=` to `ProjectInfo`, it was silently overwritten by `setup_names[0]`. Now:
- User name valid → kept as-is
- User name not found → `ValueError` with list of available setups
- No name specified → falls back to `setup_names[0]` (backwards-compatible)

### #137 / #164 — Convergence plot crashes on non-positive delta-F data
`plot_convergence_max_df` and `plot_convergence_maxdf_vs_sol` called `set_yscale("log")` unconditionally. When HFSS reports zero delta-F (perfect convergence on first pass) matplotlib's `LogLocator` raises `ValueError`. Fixed by guarding with `(s > 0).any()` — falls back to linear scale silently.

## Tests
19 new tests in `tests/test_bugfixes_094.py`. All 108 non-HFSS tests pass.

## Test plan
- [x] 19 new targeted tests pass locally
- [x] Full test suite (108 tests) passes
- [ ] CI green

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_