### PR TITLE
Bump version to 0.9.4

### DIFF
--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -90,7 +90,7 @@ __credits__ = [
     "Steven Touzard",
 ]
 __license__ = "BSD-3-Clause"
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 __maintainer__ = "Zlatko K. Minev and  Asaf Diringer"
 __email__ = "zlatko.minev@aya.yale.edu"
 __url__ = r"https://github.com/zlatko-minev/pyEPR"


### PR DESCRIPTION
Bumps `__version__` to `0.9.4` ahead of the PyPI release.

## What's in 0.9.4

**Bug fixes**
- #128 — Junction sign always printed as `(+)` (cosmetic print fix)
- #162 — QuTiP 5.x `.norm()` crash in perturbation-theory branch of `back_box_numeric`
- #169 — `ProjectInfo` `setup_name` silently ignored, hardcoded to first setup
- #137 / #164 — Convergence plot crashes on non-positive delta-F data (log-scale guard)
- #170 — Missing `return` in `get_excitations`; wrong `YAxisVec` index in `create_relative_coorinate_system_both`

**Documentation**
- Full documentation pass: physics equations, HFSS setup guide, without-HFSS guide, troubleshooting page
- Modernized installation guide with uv/pip/conda tabs
- Cleaned up landing page and API reference

**Infrastructure**
- AEDT 2021.2+ solution-type normalization (`solution_types` module)
- AEDT 2024.1+ hybrid-design workaround (`new_dm_design`, `new_dt_design`)
- `sphinx-tabs` for tabbed install instructions
- 108 non-HFSS tests passing

## Release steps (after merge)
1. Create a GitHub Release with tag `v0.9.4`
2. The `publish-to-pypi.yml` workflow triggers automatically via OIDC Trusted Publishing
3. Verify on PyPI that `pyEPR-quantum 0.9.4` appears

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_