### PR TITLE
fix #140, #141: pandas FutureWarning and report line-width per-curve loop

### DIFF
--- a/pyEPR/core_distributed_analysis.py
+++ b/pyEPR/core_distributed_analysis.py
@@ -1762,7 +1762,12 @@ class DistributedAnalysis(object):
         curves = [
             f"{report_name}:re(Mode({i})):Curve1" for i in range(1, 1 + self.n_modes)
         ]
-        # set_property(report, 'Attributes', curves, 'Line Width', 3)
+        # HFSS accepts only one curve per ChangeProperty call (confirmed against PyAEDT)
+        for curve in curves:
+            try:
+                set_property(report, "Attributes", curve, "Line Width", 3)
+            except Exception:
+                pass
         set_property(report, "Scaling", f"{report_name}:AxisY1", "Auto Units", False)
         set_property(report, "Scaling", f"{report_name}:AxisY1", "Units", "g")
         set_property(

--- a/pyEPR/core_quantum_analysis.py
+++ b/pyEPR/core_quantum_analysis.py
@@ -748,17 +748,17 @@ class QuantumAnalysis(object):
         result["Ljs"] = self.Ljs[variation]
         result["Cjs"] = self.Cjs[variation]
         try:
-            result["Q_coupling"] = self.Qm_coupling[variation][
-                self.Qm_coupling[variation].columns[junctions]
-            ][
-                modes
+            _qm = self.Qm_coupling[variation]
+            result["Q_coupling"] = _qm.loc[
+                modes, _qm.columns[junctions]
             ]  # TODO change the columns to junctions
         except:
             result["Q_coupling"] = self.Qm_coupling[variation]
 
         try:
-            result["Qs"] = self.Qs[variation][self.PM[variation].columns[junctions]][
-                modes
+            _qs_cols = self.PM[variation].columns[junctions]
+            result["Qs"] = self.Qs[variation].loc[
+                modes, _qs_cols
             ]  # TODO change the columns to junctions
         except:
             result["Qs"] = self.Qs[variation][modes]


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Two small bug fixes found during issue triage, both safe to apply without live Ansys access.

### Fix #140 — pandas `FutureWarning` in `analyze_all_variations`

**File:** `pyEPR/core_quantum_analysis.py`

Replaced chained DataFrame indexing `df[cols][rows]` with `df.loc[rows, cols]` in two places. The chained form triggers pandas' multi-dimensional indexing `FutureWarning` on modern pandas versions and will break in a future release.

### Fix #141 — `hfss_report_f_convergence` line-width styling silently broken on HFSS 2022 R2+

**File:** `pyEPR/core_distributed_analysis.py`

The `set_property` call for curve line width was passing all mode curves in a single `ChangeProperty` call. HFSS's `ChangeProperty` only accepts **one `PropServer` per call** — confirmed by cross-referencing PyAEDT's `Trace.set_trace_properties()` implementation, which loops through curves individually. Passing multiple curves in one call silently fails on HFSS 2022 R2 (the call was already commented out as a workaround).

Fix: loop through each curve with a per-curve `try/except` so a failure on one curve doesn't prevent the rest of the report from rendering.

## Test plan

- [x] 108 non-HFSS unit tests passing (`python -m pytest`)
- [ ] Manual verification of line width styling on HFSS 2022 R2+ welcome — the core logic matches PyAEDT's verified approach

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_