### PR TITLE
feat: DeprecationWarning on Project_Info, pyEPR_HFSSAnalysis, pyEPR_Analysis aliases

### DIFF
--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -200,10 +200,7 @@ from .core import (
     ProjectInfo,
     DistributedAnalysis,
     QuantumAnalysis,
-    Project_Info,
-    pyEPR_HFSSAnalysis,
-    pyEPR_Analysis,
-)  # names to be deprecated
+)
 
 __all__ = [
     "logger",
@@ -215,12 +212,32 @@ __all__ = [
     "ProjectInfo",
     "DistributedAnalysis",
     "QuantumAnalysis",
-    "Project_Info",
-    "pyEPR_HFSSAnalysis",
-    "pyEPR_Analysis",  # names to be deprecated
     "parse_units",
     "parse_units_user",
     "parse_entry",
+    # Deprecated aliases not included here; they are still accessible via __getattr__
+    # but excluded from star-imports to discourage new use.
 ]
+
+_DEPRECATED_ALIASES = {
+    "Project_Info": ("ProjectInfo", "ProjectInfo"),
+    "pyEPR_HFSSAnalysis": ("DistributedAnalysis", "DistributedAnalysis"),
+    "pyEPR_Analysis": ("QuantumAnalysis", "QuantumAnalysis"),
+}
+
+
+def __getattr__(name):
+    if name in _DEPRECATED_ALIASES:
+        import warnings
+        new_name, attr = _DEPRECATED_ALIASES[name]
+        warnings.warn(
+            f"pyEPR.{name} is deprecated and will be removed in a future release. "
+            f"Use pyEPR.{new_name} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[attr]
+    raise AttributeError(f"module 'pyEPR' has no attribute {name!r}")
+
 
 # TODO: Add "about" method. Add to tutorial

--- a/pyEPR/core.py
+++ b/pyEPR/core.py
@@ -17,7 +17,27 @@ from .project_info import ProjectInfo
 from .core_quantum_analysis import QuantumAnalysis
 from .core_distributed_analysis import DistributedAnalysis
 
-# Backwards compatibility. To be depreciated.
-Project_Info = ProjectInfo
-pyEPR_HFSSAnalysis = DistributedAnalysis
-pyEPR_Analysis = QuantumAnalysis
+_DEPRECATED_ALIASES = {
+    "Project_Info": ProjectInfo,
+    "pyEPR_HFSSAnalysis": DistributedAnalysis,
+    "pyEPR_Analysis": QuantumAnalysis,
+}
+
+_NEW_NAMES = {
+    "Project_Info": "ProjectInfo",
+    "pyEPR_HFSSAnalysis": "DistributedAnalysis",
+    "pyEPR_Analysis": "QuantumAnalysis",
+}
+
+
+def __getattr__(name):
+    if name in _DEPRECATED_ALIASES:
+        import warnings
+        warnings.warn(
+            f"pyEPR.core.{name} is deprecated and will be removed in a future release. "
+            f"Use pyEPR.core.{_NEW_NAMES[name]} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _DEPRECATED_ALIASES[name]
+    raise AttributeError(f"module 'pyEPR.core' has no attribute {name!r}")

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -1,0 +1,135 @@
+"""
+Tests for DeprecationWarning on the old pyEPR class name aliases:
+  - Project_Info       → ProjectInfo
+  - pyEPR_HFSSAnalysis → DistributedAnalysis
+  - pyEPR_Analysis     → QuantumAnalysis
+"""
+import warnings
+import pytest
+
+
+class TestTopLevelAliases:
+    """pyEPR.Project_Info etc. should warn and return the right class."""
+
+    def test_project_info_alias_warns(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cls = pyEPR.Project_Info
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "Project_Info" in str(w[0].message)
+        assert "ProjectInfo" in str(w[0].message)
+
+    def test_project_info_alias_returns_correct_class(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = pyEPR.Project_Info
+        assert cls is pyEPR.ProjectInfo
+
+    def test_hfss_analysis_alias_warns(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cls = pyEPR.pyEPR_HFSSAnalysis
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "pyEPR_HFSSAnalysis" in str(w[0].message)
+        assert "DistributedAnalysis" in str(w[0].message)
+
+    def test_hfss_analysis_alias_returns_correct_class(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = pyEPR.pyEPR_HFSSAnalysis
+        assert cls is pyEPR.DistributedAnalysis
+
+    def test_quantum_analysis_alias_warns(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cls = pyEPR.pyEPR_Analysis
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "pyEPR_Analysis" in str(w[0].message)
+        assert "QuantumAnalysis" in str(w[0].message)
+
+    def test_quantum_analysis_alias_returns_correct_class(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = pyEPR.pyEPR_Analysis
+        assert cls is pyEPR.QuantumAnalysis
+
+    def test_unknown_attribute_raises(self):
+        import pyEPR
+        with pytest.raises(AttributeError):
+            _ = pyEPR.nonexistent_name_xyz
+
+
+class TestCoreModuleAliases:
+    """pyEPR.core.Project_Info etc. should warn and return the right class."""
+
+    def test_project_info_alias_warns(self):
+        from pyEPR import core
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            cls = core.Project_Info
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "Project_Info" in str(w[0].message)
+
+    def test_project_info_alias_returns_correct_class(self):
+        from pyEPR import core
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = core.Project_Info
+        assert cls is core.ProjectInfo
+
+    def test_hfss_analysis_alias_returns_correct_class(self):
+        from pyEPR import core
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = core.pyEPR_HFSSAnalysis
+        assert cls is core.DistributedAnalysis
+
+    def test_quantum_analysis_alias_returns_correct_class(self):
+        from pyEPR import core
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            cls = core.pyEPR_Analysis
+        assert cls is core.QuantumAnalysis
+
+    def test_unknown_attribute_raises(self):
+        from pyEPR import core
+        with pytest.raises(AttributeError):
+            _ = core.nonexistent_name_xyz
+
+
+class TestCanonicalNamesNoWarning:
+    """Canonical names must not emit any warnings."""
+
+    def test_project_info_no_warning(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = pyEPR.ProjectInfo
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert dep_warnings == []
+
+    def test_distributed_analysis_no_warning(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = pyEPR.DistributedAnalysis
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert dep_warnings == []
+
+    def test_quantum_analysis_no_warning(self):
+        import pyEPR
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = pyEPR.QuantumAnalysis
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert dep_warnings == []


### PR DESCRIPTION
## Summary

Uses module-level `__getattr__` (PEP 562, Python 3.7+) in both `pyEPR/__init__.py` and `pyEPR/core.py` so accessing the old names still works but emits a `DeprecationWarning` pointing to the canonical replacement.

| Deprecated | Canonical |
|---|---|
| `Project_Info` | `ProjectInfo` |
| `pyEPR_HFSSAnalysis` | `DistributedAnalysis` |
| `pyEPR_Analysis` | `QuantumAnalysis` |

Canonical names are completely unaffected — no warning, no behaviour change. The deprecated names are removed from `__all__` so `from pyEPR import *` no longer promotes them, but they remain directly accessible for backwards compatibility.

## Files changed

| File | Change |
|------|--------|
| `pyEPR/__init__.py` | Remove deprecated names from direct imports + `__all__`; add `__getattr__` |
| `pyEPR/core.py` | Replace simple assignments with `__getattr__` |
| `tests/test_deprecation_aliases.py` | 15 new tests: warning fires, correct class returned, canonical names clean |

## Test plan

- [x] `pytest tests/test_deprecation_aliases.py -v` — all 15 pass
- [x] `pytest` — full suite, 135 passed
- [x] `pylint --errors-only pyEPR/` — clean

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_