### PR TITLE
feat: exact cosine diagonalization for strongly anharmonic circuits (use_full_cos=True)

### DIFF
--- a/_tutorial_notebooks/Tutorial 5. Generic junction potential and fluxonium EPR.ipynb
+++ b/_tutorial_notebooks/Tutorial 5. Generic junction potential and fluxonium EPR.ipynb
@@ -1,0 +1,395 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tutorial 5: Generic Junction Potential and Fluxonium EPR\n",
+    "\n",
+    "This tutorial covers two advanced features of the pyEPR numerical diagonalization:\n",
+    "\n",
+    "1. **Exact cosine** (`use_full_cos=True`) — avoids truncation errors for strongly anharmonic circuits such as fluxonium (φ_zpf ≳ 1).\n",
+    "2. **Generic nonlinear potential** (`make_nonlinear_potential`) — lets you supply any scalar potential V(φ) expanded around the operating bias point.\n",
+    "\n",
+    "## Physics background\n",
+    "\n",
+    "The EPR Hamiltonian is split as\n",
+    "\n",
+    "$$H = H_{\\rm lin} + H_{\\rm nl},$$\n",
+    "\n",
+    "where $H_{\\rm lin}$ is built from the HFSS linearised eigenfrequencies (which already encode the **harmonic** Josephson energy $E_J\\varphi^2/2$ via the linearised inductance $L_j$). The nonlinear correction must therefore subtract exactly the constant and quadratic parts of the junction potential:\n",
+    "\n",
+    "$$H_{\\rm nl} = -\\sum_j \\frac{E_{J,j}}{h}\\, {\\rm nl}(\\hat\\varphi_j), \\qquad\n",
+    "{\\rm nl}(\\delta\\varphi) = \\frac{V(\\varphi_0+\\delta\\varphi)-V(\\varphi_0)-\\tfrac12 V''(\\varphi_0)\\,\\delta\\varphi^2}{|V''(\\varphi_0)|}$$\n",
+    "\n",
+    "For the standard Josephson junction $V(\\varphi) = \\cos\\varphi$:\n",
+    "\n",
+    "$$V''(0) = -1 \\implies {\\rm nl}(\\delta\\varphi) = \\cos(\\delta\\varphi) - 1 + \\tfrac{\\delta\\varphi^2}{2}\n",
+    "= -\\frac{\\delta\\varphi^4}{4!} + \\frac{\\delta\\varphi^6}{6!} - \\cdots$$\n",
+    "\n",
+    "The `cos_approx` function computes the **truncated** Taylor series of this correction. For weakly anharmonic circuits (transmon, $\\varphi_{\\rm zpf} \\lesssim 0.3$) truncation at order $\\varphi^{16}$ is more than sufficient. For strongly anharmonic circuits (fluxonium, $\\varphi_{\\rm zpf} \\sim 1{-}3$) the series may converge poorly or diverge — the **exact** matrix-exponential path is then required.\n",
+    "\n",
+    "> **References**\n",
+    "> - Z. K. Minev *et al.*, [arXiv:2010.00620](https://arxiv.org/abs/2010.00620) — Energy-participation quantisation of Josephson circuits (pyEPR original paper).\n",
+    "> - A. Petrescu, C. T. Hann, Z. K. Minev *et al.*, [arXiv:2411.15039](https://arxiv.org/abs/2411.15039) — EPR analysis for very anharmonic superconducting circuits (fluxonium full-cosine method).\n",
+    "> - G. Zhu, D. G. Ferguson, V. E. Manucharyan, and J. Koch, [Phys. Rev. B **87**, 024510 (2013)](https://doi.org/10.1103/PhysRevB.87.024510) — Circuit QED with fluxonium qubits.\n",
+    "> - N. A. Masluk, I. M. Pop, A. Kamal, Z. K. Minev, M. H. Devoret, [Phys. Rev. Lett. **109**, 137002 (2012)](https://doi.org/10.1103/PhysRevLett.109.137002) — Microwave characterisation of Josephson junction arrays.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pyEPR.calcs.back_box_numeric import (\n",
+    "    epr_numerical_diagonalization,\n",
+    "    make_nonlinear_potential,\n",
+    "    cos_full_correction,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Part 1 — Transmon: truncated vs. exact cosine\n",
+    "\n",
+    "For a transmon-like circuit the zero-point phase fluctuation is small ($\\varphi_{\\rm zpf} \\approx 0.15$), so the truncated Taylor series converges quickly. We verify that `cos_trunc=16` and `use_full_cos=True` agree to better than 0.1 %."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Transmon-like parameters\n",
+    "freqs   = np.array([5.0])     # GHz\n",
+    "Ljs     = np.array([10e-9])   # H\n",
+    "phi_zpf = np.array([[0.15]])  # reduced ZPF\n",
+    "\n",
+    "f_trunc, chi_trunc = epr_numerical_diagonalization(\n",
+    "    freqs, Ljs, phi_zpf, cos_trunc=16, fock_trunc=15\n",
+    ")\n",
+    "f_full, chi_full = epr_numerical_diagonalization(\n",
+    "    freqs, Ljs, phi_zpf, fock_trunc=15, use_full_cos=True\n",
+    ")\n",
+    "\n",
+    "print(f\"Dressed frequency  — truncated: {np.real(f_trunc[0]):.6f} GHz  |  exact: {np.real(f_full[0]):.6f} GHz\")\n",
+    "print(f\"Anharmonicity χ    — truncated: {np.real(chi_trunc[0,0]):.4f} MHz  |  exact: {np.real(chi_full[0,0]):.4f} MHz\")\n",
+    "rel_diff = abs(np.real(f_full[0]) - np.real(f_trunc[0])) / abs(np.real(f_full[0]))\n",
+    "print(f\"Relative difference in frequency: {rel_diff:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Part 2 — Fluxonium: exact cosine is essential\n",
+    "\n",
+    "For a fluxonium-like circuit $\\varphi_{\\rm zpf} \\approx 2$. The truncated series at order $\\varphi^8$ gives qualitatively wrong results; the exact cosine (`use_full_cos=True`) is required. This is the main result of [arXiv:2411.15039](https://arxiv.org/abs/2411.15039)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fluxonium-like parameters (large phi_zpf → strongly anharmonic)\n",
+    "freqs_fl   = np.array([0.5])     # GHz\n",
+    "Ljs_fl     = np.array([500e-9])  # H  (large superinductance)\n",
+    "phi_zpf_fl = np.array([[2.0]])   # phi_zpf >> 1\n",
+    "\n",
+    "# Low truncation — INACCURATE\n",
+    "f_low, chi_low = epr_numerical_diagonalization(\n",
+    "    freqs_fl, Ljs_fl, phi_zpf_fl, cos_trunc=4, fock_trunc=25\n",
+    ")\n",
+    "\n",
+    "# Exact cosine — CORRECT\n",
+    "f_exact, chi_exact = epr_numerical_diagonalization(\n",
+    "    freqs_fl, Ljs_fl, phi_zpf_fl, fock_trunc=25, use_full_cos=True\n",
+    ")\n",
+    "\n",
+    "print(\"Fluxonium — low truncation vs. exact cosine:\")\n",
+    "print(f\"  f (trunc=4):  {np.real(f_low[0]):.4f} GHz\")\n",
+    "print(f\"  f (exact):    {np.real(f_exact[0]):.4f} GHz\")\n",
+    "rel = abs(np.real(f_exact[0]) - np.real(f_low[0])) / abs(np.real(f_exact[0]))\n",
+    "print(f\"  Relative error from low truncation: {rel:.1%}  ← significant!\")\n",
+    "print()\n",
+    "print(f\"  χ (trunc=4): {np.real(chi_low[0,0]):.2f} MHz\")\n",
+    "print(f\"  χ (exact):   {np.real(chi_exact[0,0]):.2f} MHz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Part 3 — Generic potential: expanding around the bias minimum\n",
+    "\n",
+    "`make_nonlinear_potential(V, phi_min)` converts any scalar Python function $V(\\varphi)$ into the operator-valued EPR correction. The function:\n",
+    "\n",
+    "1. Evaluates $V_0 = V(\\varphi_0)$ and $V'' = V''(\\varphi_0)$ (numerically).\n",
+    "2. Returns a callable `nl(φ_op)` that computes\n",
+    "   $$\\mathrm{nl}(\\delta\\varphi) = \\frac{V(\\varphi_0+\\delta\\varphi) - V_0 - \\tfrac{V''}{2}\\delta\\varphi^2}{|V''|}$$\n",
+    "   as a qutip operator via eigendecomposition of the phase operator.\n",
+    "\n",
+    "**When to use this**: when the junction potential is not a simple cosine centred at zero — e.g., a flux-biased junction, an asymmetric SQUID, or any exotic Josephson element.\n",
+    "\n",
+    "### 3a. Standard junction — recovering the default\n",
+    "\n",
+    "Passing `V = np.cos` recovers `cos_full_correction` to numerical precision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nl_from_cos = make_nonlinear_potential(np.cos)   # V(phi) = cos(phi), phi_min=0\n",
+    "\n",
+    "f_gen, chi_gen = epr_numerical_diagonalization(\n",
+    "    freqs, Ljs, phi_zpf, fock_trunc=15,\n",
+    "    non_linear_potential=nl_from_cos,\n",
+    ")\n",
+    "print(\"Standard JJ via make_nonlinear_potential vs. use_full_cos=True:\")\n",
+    "print(f\"  f  — generic: {np.real(f_gen[0]):.6f} GHz  |  exact: {np.real(f_full[0]):.6f} GHz\")\n",
+    "print(f\"  χ  — generic: {np.real(chi_gen[0,0]):.4f} MHz  |  exact: {np.real(chi_full[0,0]):.4f} MHz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3b. Flux-biased junction at $\\varphi_{\\rm ext}$\n",
+    "\n",
+    "A Josephson junction biased by external flux $\\varphi_{\\rm ext}$ has potential\n",
+    "\n",
+    "$$U(\\varphi) = -E_J \\cos(\\varphi - \\varphi_{\\rm ext})$$\n",
+    "\n",
+    "The minimum is at $\\varphi_0 = \\varphi_{\\rm ext}$.  After expansion around the minimum, the potential in the fluctuation variable $\\delta\\varphi = \\varphi - \\varphi_0$ is simply $-E_J^{\\rm eff}\\cos(\\delta\\varphi)$, where the effective Josephson energy $E_J^{\\rm eff} = E_J\\cos(\\varphi_{\\rm ext})$ is encoded in the linearised inductance $L_j$ from the HFSS EPR run.\n",
+    "\n",
+    "This means the nonlinear correction is *identical* to the unbiased case — `make_nonlinear_potential` confirms this automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phi_ext = np.pi / 6   # 30 degrees external flux\n",
+    "\n",
+    "nl_biased = make_nonlinear_potential(\n",
+    "    lambda phi: np.cos(phi - phi_ext),\n",
+    "    phi_min=phi_ext,\n",
+    ")\n",
+    "\n",
+    "f_bias, chi_bias = epr_numerical_diagonalization(\n",
+    "    freqs, Ljs, phi_zpf, fock_trunc=15,\n",
+    "    non_linear_potential=nl_biased,\n",
+    ")\n",
+    "\n",
+    "print(f\"Flux-biased junction at phi_ext = pi/6:\")\n",
+    "print(f\"  f  = {np.real(f_bias[0]):.6f} GHz\")\n",
+    "print(f\"  χ  = {np.real(chi_bias[0,0]):.4f} MHz\")\n",
+    "print()\n",
+    "print(\"(Same as unbiased since Ej_eff is encoded in Lj passed to the EPR solver.\")\n",
+    "print(\" Only use a different Lj = (Φ₀/2π)² / Ej_eff for the biased case.)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3c. Asymmetric SQUID\n",
+    "\n",
+    "For an asymmetric SQUID (two junctions with energies $E_{J1}$, $E_{J2}$) at external flux $\\varphi_{\\rm ext}$, the effective potential seen by the common mode phase is\n",
+    "\n",
+    "$$V_{\\rm SQUID}(\\varphi) = \\cos\\varphi\\cos\\varphi_{\\rm ext} + d\\sin\\varphi\\sin\\varphi_{\\rm ext}$$\n",
+    "\n",
+    "where $d = (E_{J1}-E_{J2})/(E_{J1}+E_{J2})$ is the asymmetry parameter and the result is normalised by $E_{J1}+E_{J2}$ (see [arXiv:2010.00620](https://arxiv.org/abs/2010.00620), §IV).  The potential minimum is at\n",
+    "\n",
+    "$$\\varphi_0 = \\arctan(-d\\tan\\varphi_{\\rm ext}).$$\n",
+    "\n",
+    "`make_nonlinear_potential` handles the expansion around $\\varphi_0$ and normalisation automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phi_ext = 0.4   # external flux (reduced units)\n",
+    "d       = 0.15  # asymmetry parameter\n",
+    "\n",
+    "def V_squid(phi):\n",
+    "    \"\"\"Asymmetric SQUID normalised potential.\"\"\"\n",
+    "    return np.cos(phi) * np.cos(phi_ext) + d * np.sin(phi) * np.sin(phi_ext)\n",
+    "\n",
+    "# Minimum of -Ej * V_squid (maximum of V_squid)\n",
+    "phi_min_squid = np.arctan(-d * np.tan(phi_ext)) % np.pi\n",
+    "\n",
+    "print(f\"SQUID bias phi_ext = {phi_ext:.2f} rad,  asymmetry d = {d}\")\n",
+    "print(f\"Potential minimum at phi_min = {phi_min_squid:.4f} rad\")\n",
+    "print(f\"V''(phi_min) = {-(np.cos(phi_min_squid)*np.cos(phi_ext) + d*np.sin(phi_min_squid)*np.sin(phi_ext)):.4f}\")\n",
+    "\n",
+    "nl_squid = make_nonlinear_potential(V_squid, phi_min=phi_min_squid)\n",
+    "\n",
+    "f_sq, chi_sq = epr_numerical_diagonalization(\n",
+    "    freqs, Ljs, phi_zpf, fock_trunc=15,\n",
+    "    non_linear_potential=nl_squid,\n",
+    ")\n",
+    "print(f\"\\nAsymmetric SQUID:  f = {np.real(f_sq[0]):.4f} GHz,  χ = {np.real(chi_sq[0,0]):.4f} MHz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3d. Visualising the potential and its nonlinear correction\n",
+    "\n",
+    "Understanding what `make_nonlinear_potential` subtracts is key to using it correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phi = np.linspace(-np.pi, np.pi, 500)\n",
+    "\n",
+    "# ── Standard JJ ─────────────────────────────────────────────────────────────\n",
+    "V = np.cos(phi)                        # full potential (normalised)\n",
+    "V0 = np.cos(0)                         # = 1\n",
+    "Vpp = -np.cos(0)                       # = -1  (V'' at the minimum)\n",
+    "V_harm = V0 + Vpp / 2 * phi**2         # quadratic approx (already in H_lin)\n",
+    "nl = (V - V0 - Vpp / 2 * phi**2) / abs(Vpp)  # nonlinear correction\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "\n",
+    "ax = axes[0]\n",
+    "ax.plot(phi, V,      label=r'$V(\\varphi) = \\cos\\varphi$', lw=2)\n",
+    "ax.plot(phi, V_harm, label=r'Harmonic approx $V_0 + V\\'\\'/2\\,\\varphi^2$', lw=2, ls='--')\n",
+    "ax.set_xlabel(r'$\\varphi$ (rad)')\n",
+    "ax.set_ylabel(r'$V / E_J$')\n",
+    "ax.set_title('Junction potential (standard JJ)')\n",
+    "ax.legend()\n",
+    "ax.set_xlim(-np.pi, np.pi)\n",
+    "\n",
+    "ax = axes[1]\n",
+    "ax.plot(phi, nl, lw=2, color='C2',\n",
+    "        label=r'$\\mathrm{nl}(\\varphi) = \\cos\\varphi - 1 + \\varphi^2/2$')\n",
+    "ax.axhline(0, color='k', lw=0.5)\n",
+    "ax.set_xlabel(r'$\\varphi$ (rad)')\n",
+    "ax.set_ylabel(r'$\\mathrm{nl}(\\varphi)$')\n",
+    "ax.set_title('Nonlinear correction (what EPR adds)')\n",
+    "ax.legend()\n",
+    "ax.set_xlim(-np.pi, np.pi)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "print(\"The harmonic approximation (dashed) is already captured by H_lin.\")\n",
+    "print(\"The EPR nonlinear correction nl(φ) adds everything beyond the quadratic.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Part 4 — Convergence comparison: transmon vs. fluxonium\n",
+    "\n",
+    "We sweep the Fock-space truncation and compare the dressed frequency as a function of truncation order for both circuit types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fock_values = [8, 10, 12, 15, 20, 25]\n",
+    "\n",
+    "f_transmon_full  = []\n",
+    "f_fluxonium_full = []\n",
+    "\n",
+    "for ft in fock_values:\n",
+    "    f_t, _ = epr_numerical_diagonalization(freqs,    Ljs,    phi_zpf,    fock_trunc=ft, use_full_cos=True)\n",
+    "    f_f, _ = epr_numerical_diagonalization(freqs_fl, Ljs_fl, phi_zpf_fl, fock_trunc=ft, use_full_cos=True)\n",
+    "    f_transmon_full.append(np.real(f_t[0]))\n",
+    "    f_fluxonium_full.append(np.real(f_f[0]))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "\n",
+    "for ax, label, values, ref in [\n",
+    "    (axes[0], 'Transmon (φ_zpf=0.15)', f_transmon_full,  f_transmon_full[-1]),\n",
+    "    (axes[1], 'Fluxonium (φ_zpf=2.0)', f_fluxonium_full, f_fluxonium_full[-1]),\n",
+    "]:\n",
+    "    rel_err = [abs(f - ref) / abs(ref) * 100 for f in values]\n",
+    "    ax.semilogy(fock_values, rel_err, 'o-', lw=2)\n",
+    "    ax.set_xlabel('Fock truncation')\n",
+    "    ax.set_ylabel('Relative error vs. fock_trunc=25 (%)')\n",
+    "    ax.set_title(label)\n",
+    "    ax.grid(True, which='both', alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary and API cheat-sheet\n",
+    "\n",
+    "| Scenario | Recommended call |\n",
+    "|---|---|\n",
+    "| Transmon (φ_zpf ≲ 0.3) | `epr_numerical_diagonalization(..., cos_trunc=8)` (default) |\n",
+    "| Fluxonium / strongly anharmonic (φ_zpf ≳ 1) | `epr_numerical_diagonalization(..., use_full_cos=True)` |\n",
+    "| Flux-biased JJ at φ_ext | `make_nonlinear_potential(lambda φ: cos(φ-φ_ext), phi_min=φ_ext)` |\n",
+    "| Asymmetric SQUID | `make_nonlinear_potential(V_squid, phi_min=phi_min_squid)` |\n",
+    "| Arbitrary junction potential V(φ) | `make_nonlinear_potential(V, phi_min=phi_min_V)` |\n",
+    "\n",
+    "The `non_linear_potential` argument of `epr_numerical_diagonalization` and `black_box_hamiltonian` accepts any callable `nl(φ_op: Qobj) -> Qobj` that returns the **correction beyond the quadratic**, normalised by $|V''(\\varphi_0)|$. Use `make_nonlinear_potential` to construct this automatically from a scalar Python function.\n",
+    "\n",
+    "### References\n",
+    "\n",
+    "- Z. K. Minev *et al.*, *Energy-participation quantization of Josephson circuits*, [npj Quantum Information **7**, 131 (2021)](https://doi.org/10.1038/s41534-021-00461-8) ([arXiv:2010.00620](https://arxiv.org/abs/2010.00620)).\n",
+    "- A. Petrescu, C. T. Hann, Z. K. Minev *et al.*, *EPR analysis for very anharmonic superconducting circuits*, [arXiv:2411.15039 (2024)](https://arxiv.org/abs/2411.15039).\n",
+    "- V. E. Manucharyan *et al.*, *Fluxonium: Single Cooper-pair circuit free of charge offsets*, [Science **326**, 113 (2009)](https://doi.org/10.1126/science.1177114).\n",
+    "- G. Zhu, D. G. Ferguson, V. E. Manucharyan, J. Koch, *Circuit QED with fluxonium qubits*, [Phys. Rev. B **87**, 024510 (2013)](https://doi.org/10.1103/PhysRevB.87.024510).\n",
+    "- N. A. Masluk *et al.* (incl. Z. K. Minev), *Microwave characterisation of Josephson junction arrays*, [Phys. Rev. Lett. **109**, 137002 (2012)](https://doi.org/10.1103/PhysRevLett.109.137002).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyEPR/calcs/back_box_numeric.py
+++ b/pyEPR/calcs/back_box_numeric.py
@@ -31,10 +31,12 @@ __all__ = [
     "make_dispersive",
     "black_box_hamiltonian",
     "black_box_hamiltonian_nq",
+    "cos_full_correction",
 ]
 
 dot = MatrixOps.dot
 cos_approx = MatrixOps.cos_approx
+cos_full_correction = MatrixOps.cos_full_correction
 
 
 # ==============================================================================
@@ -51,17 +53,54 @@ def epr_numerical_diagonalization(
     use_1st_order=False,
     return_H=False,
     non_linear_potential=None,
+    use_full_cos=False,
 ):
-    """
-    Numerical diagonalization for pyEPR. Ask Zlatko for details.
+    """Numerical diagonalization of the EPR Hamiltonian.
 
-    :param fs: (GHz, not radians) Linearized model, H_lin, normal mode frequencies in Hz, length M
-    :param ljs: (Henries) junction linearized inductances in Henries, length J
-    :param fzpfs: (reduced) Reduced Zero-point fluctuation of the junction fluxes for each mode
-                across each junction, shape MxJ
+    Parameters
+    ----------
+    freqs : array-like
+        Linearised normal-mode frequencies in **GHz** (not radians), length M.
+    Ljs : array-like
+        Junction linearised inductances in **Henries**, length J.
+    ϕzpf : array-like
+        Reduced zero-point flux fluctuations, shape M × J.
+    cos_trunc : int, optional
+        Order of the Taylor-series truncation of cos(φ).  Only used when
+        ``use_full_cos=False`` (default 8).  Ignored when ``use_full_cos=True``.
+    fock_trunc : int, optional
+        Fock-space truncation (number of levels per mode).  Default 9.
+    use_1st_order : bool, optional
+        Use first-order perturbation theory instead of full diagonalization.
+        Default ``False``.
+    return_H : bool, optional
+        If ``True``, also return the Hamiltonian Qobj.  Default ``False``.
+    non_linear_potential : callable, optional
+        Custom replacement for the cosine potential.  Must accept a qutip Qobj
+        (the phase-operator argument) and return a qutip Qobj.  Overrides both
+        ``cos_trunc`` and ``use_full_cos``.
+    use_full_cos : bool, optional
+        If ``True``, use the **exact** matrix-exponential cosine
+        ``cos(φ) = (e^{iφ} + e^{-iφ}) / 2`` instead of the truncated Taylor
+        series.  Recommended for strongly anharmonic circuits such as
+        **fluxonium**, where large zero-point phase fluctuations make the
+        truncated expansion inaccurate.  Default ``False`` (truncated series).
 
-    :return: Hamiltonian mode freq and dispersive shifts. Shifts are in MHz.
-             Shifts have flipped sign so that down shift is positive.
+    Returns
+    -------
+    f_ND : numpy.ndarray
+        Dressed mode frequencies in **GHz**.
+    χ_ND : numpy.ndarray
+        Cross-Kerr / anharmonicity matrix in **MHz** (positive = red shift).
+    Hs : qutip.Qobj
+        Full Hamiltonian Qobj — only returned when ``return_H=True``.
+
+    Note
+    ----
+    For transmon-like circuits (small φ_zpf) the truncated cosine (default) is
+    accurate and faster.  For fluxonium or other circuits where φ_zpf ≳ 1 rad,
+    set ``use_full_cos=True`` to avoid systematic errors in the anharmonicity.
+    See arXiv:2411.15039 for a detailed comparison.
     """
 
     freqs, Ljs, ϕzpf = map(np.array, (freqs, Ljs, ϕzpf))
@@ -69,6 +108,9 @@ def epr_numerical_diagonalization(
     assert all(
         Ljs < 1e-3
     ), "Please input the inductances in Henries. \N{nauseated face}"
+
+    if non_linear_potential is None and use_full_cos:
+        non_linear_potential = cos_full_correction
 
     Hs = black_box_hamiltonian(
         freqs * 1e9,
@@ -187,9 +229,10 @@ def make_dispersive(
         # assert type(
         #    H) == qutip.qobj.Qobj, "Please pass in either a list of Qobjs or Qobj for the Hamiltonian"
 
-    print("Starting the diagonalization")
+    from .. import logger as _logger
+    _logger.info("Starting diagonalization (%d×%d matrix)", H.shape[0], H.shape[0])
     evals, evecs = H.eigenstates()
-    print("Finished the diagonalization")
+    _logger.info("Diagonalization complete")
     evals -= evals[0]
 
     N = int(np.log(H.shape[0]) / np.log(fock_trunc))  # number of modes
@@ -203,7 +246,7 @@ def make_dispersive(
 
     if use_1st_order:
         num_modes = N
-        print("Using 1st O")
+        _logger.debug("Using 1st-order perturbation theory")
 
         def multi_index_2_vector(d, num_modes, fock_trunc):
             return tensor([basis(fock_trunc, d.get(i, 0)) for i in range(num_modes)])

--- a/pyEPR/calcs/back_box_numeric.py
+++ b/pyEPR/calcs/back_box_numeric.py
@@ -32,11 +32,143 @@ __all__ = [
     "black_box_hamiltonian",
     "black_box_hamiltonian_nq",
     "cos_full_correction",
+    "make_nonlinear_potential",
 ]
 
 dot = MatrixOps.dot
 cos_approx = MatrixOps.cos_approx
 cos_full_correction = MatrixOps.cos_full_correction
+
+
+def make_nonlinear_potential(V, phi_min=0.0, _eps=1e-5):
+    r"""Build an EPR-compatible nonlinear potential from a user-supplied scalar function.
+
+    **Background — EPR Hamiltonian split**
+
+    In the EPR framework the Hamiltonian is decomposed as
+
+    .. math::
+
+        H = H_{\rm lin} - \sum_j \frac{E_{J,j}}{h}\,
+            \underbrace{\Bigl[V(\varphi_{j,0} + \delta\varphi_j)
+            - V(\varphi_{j,0})
+            - \tfrac12 V''(\varphi_{j,0})\,\delta\varphi_j^2
+            \Bigr] / |V''(\varphi_{j,0})|}_{\displaystyle \mathrm{nl}(\delta\varphi_j)}
+
+    :math:`H_{\rm lin}` is built from the HFSS eigenmode frequencies, which already
+    encode the **harmonic** (quadratic) Josephson energy via the linearised inductance
+    :math:`L_j`.  The nonlinear correction ``nl(δφ)`` must therefore subtract exactly
+    the constant and quadratic parts of *V* that are already captured.
+
+    The function returned by :func:`make_nonlinear_potential` does this automatically:
+    it evaluates *V* as an operator (via eigendecomposition of the phase operator),
+    subtracts the constant :math:`V(\varphi_0)` and the quadratic term
+    :math:`\tfrac12 V''(\varphi_0)\,\delta\varphi^2`, and normalises by
+    :math:`|V''(\varphi_0)|` for consistency with the effective Josephson energy
+    :math:`E_{J,\rm eff} = (\Phi_0/2\pi)^2 / L_j`.
+
+    **Convention**: *V* is the normalised potential appearing in :math:`U_J = -E_J V(\varphi)`.
+    For a standard Josephson junction :math:`V(\varphi) = \cos\varphi`, giving
+    :math:`V''(0) = -1` and recovering the default :func:`cos_full_correction`.
+
+    Parameters
+    ----------
+    V : callable
+        Scalar potential function ``V(phi: float) -> float``.
+
+        *phi* is the **reduced phase in the absolute frame** (not a fluctuation).
+        Common choices:
+
+        * ``np.cos`` — standard Josephson junction (reproduces :func:`cos_full_correction`)
+        * ``lambda phi: np.cos(phi - phi_ext)`` — flux-biased junction at *phi_ext*
+        * ``lambda phi: d_J * np.cos(phi - phi_ext)`` — asymmetric SQUID (scaled)
+
+    phi_min : float, optional
+        Phase at the potential minimum (equilibrium / bias point) in the same frame
+        as *V*.  The EPR phase-fluctuation operator δφ is centred here.
+        Default 0 (unbiased junction at its minimum).
+    _eps : float, optional
+        Finite-difference step for estimating :math:`V''(\varphi_0)`.  Default 1e-5.
+
+    Returns
+    -------
+    callable
+        ``nl(phi_op: qutip.Qobj) -> qutip.Qobj``, suitable as the
+        ``non_linear_potential`` argument of :func:`epr_numerical_diagonalization`
+        or :func:`black_box_hamiltonian`.
+
+    Raises
+    ------
+    ValueError
+        If :math:`|V''(\varphi_0)| < 10^{-12}`, indicating *phi_min* is not a
+        proper quadratic extremum of *V*.
+
+    Examples
+    --------
+    **Standard junction** — equivalent to the built-in default:
+
+    >>> import numpy as np
+    >>> nl = make_nonlinear_potential(np.cos)   # V(phi) = cos(phi), phi_min=0
+    >>> # nl(phi_op) ≡ cos_full_correction(phi_op)
+
+    **Flux-biased junction** at half a flux quantum (φ_ext = π/2):
+
+    >>> phi_ext = np.pi / 2
+    >>> nl = make_nonlinear_potential(lambda phi: np.cos(phi - phi_ext),
+    ...                               phi_min=phi_ext)
+    >>> f_ND, chi_ND = epr_numerical_diagonalization(
+    ...     freqs, Ljs, phi_zpf, fock_trunc=20,
+    ...     non_linear_potential=nl,
+    ... )
+
+    **Asymmetric SQUID** tuned to flux bias *phi_ext*, asymmetry *d = (Ej1-Ej2)/(Ej1+Ej2)*:
+
+    >>> import numpy as np
+    >>> phi_ext = 0.4  # external flux in reduced units
+    >>> d = 0.1       # junction asymmetry
+    >>> # Effective potential (see arXiv:2010.00620, §IV)
+    >>> def V_squid(phi):
+    ...     return np.cos(phi) * np.cos(phi_ext) + d * np.sin(phi) * np.sin(phi_ext)
+    >>> phi_min = np.arctan(-d * np.tan(phi_ext))   # minimum of -Ej*V_squid
+    >>> nl = make_nonlinear_potential(V_squid, phi_min=phi_min)
+
+    Notes
+    -----
+    Uses eigendecomposition of φ_op to evaluate *V* as a matrix function — exact for
+    any analytic *V* but slightly slower than the Taylor-series cosine default for
+    small φ_zpf.  For production runs with standard junctions, prefer
+    :func:`cos_full_correction` (``use_full_cos=True``) or the default ``cos_trunc``
+    path; use :func:`make_nonlinear_potential` when the junction potential is not
+    a simple cosine centred at zero.
+
+    See Also
+    --------
+    cos_full_correction : Exact nonlinear potential for the standard Josephson junction.
+    epr_numerical_diagonalization : Top-level solver; accepts ``non_linear_potential``.
+
+    References
+    ----------
+    * Z. K. Minev *et al.*, arXiv:2010.00620 — EPR quantisation of Josephson circuits.
+    * arXiv:2411.15039 — EPR analysis for very anharmonic superconducting circuits.
+    """
+    V0 = V(phi_min)
+    Vpp = (V(phi_min + _eps) - 2.0 * V0 + V(phi_min - _eps)) / _eps ** 2
+    abs_Vpp = abs(Vpp)
+
+    if abs_Vpp < 1e-12:
+        raise ValueError(
+            f"V''(phi_min={phi_min}) ≈ 0: phi_min is not a quadratic extremum of V. "
+            "Provide the correct potential minimum via phi_min."
+        )
+
+    def nl(phi_op):
+        """Nonlinear EPR correction nl(δφ) = [V(φ_min+δφ) - V(φ_min) - V''(φ_min)/2·δφ²] / |V''(φ_min)|."""
+        import qutip
+        V_op = MatrixOps.apply_scalar_function(phi_op, lambda x: V(phi_min + x))
+        I = qutip.qeye(phi_op.dims[0])
+        return (V_op - V0 * I - (Vpp / 2.0) * phi_op ** 2) / abs_Vpp
+
+    return nl
 
 
 # ==============================================================================
@@ -76,9 +208,19 @@ def epr_numerical_diagonalization(
     return_H : bool, optional
         If ``True``, also return the Hamiltonian Qobj.  Default ``False``.
     non_linear_potential : callable, optional
-        Custom replacement for the cosine potential.  Must accept a qutip Qobj
-        (the phase-operator argument) and return a qutip Qobj.  Overrides both
-        ``cos_trunc`` and ``use_full_cos``.
+        Custom nonlinear potential function.  Must accept a qutip Qobj φ (the
+        reduced phase-fluctuation operator) and return a qutip Qobj equal to the
+        **correction beyond the quadratic** of the junction potential:
+
+        .. math::
+
+            \\mathrm{nl}(\\delta\\varphi) =
+              \\frac{V(\\varphi_0 + \\delta\\varphi) - V(\\varphi_0)
+                    - \\tfrac{1}{2}V''(\\varphi_0)\\,\\delta\\varphi^2}
+                   {|V''(\\varphi_0)|}
+
+        Use :func:`make_nonlinear_potential` to build this callable from any
+        scalar Python function.  Overrides both ``cos_trunc`` and ``use_full_cos``.
     use_full_cos : bool, optional
         If ``True``, use the **exact** matrix-exponential cosine
         ``cos(φ) = (e^{iφ} + e^{-iφ}) / 2`` instead of the truncated Taylor
@@ -95,12 +237,33 @@ def epr_numerical_diagonalization(
     Hs : qutip.Qobj
         Full Hamiltonian Qobj — only returned when ``return_H=True``.
 
-    Note
-    ----
-    For transmon-like circuits (small φ_zpf) the truncated cosine (default) is
-    accurate and faster.  For fluxonium or other circuits where φ_zpf ≳ 1 rad,
-    set ``use_full_cos=True`` to avoid systematic errors in the anharmonicity.
-    See arXiv:2411.15039 for a detailed comparison.
+    Notes
+    -----
+    **Choosing the right potential path:**
+
+    * Small φ_zpf (transmon, φ_zpf ≲ 0.3): default ``cos_trunc=8`` is fast and
+      accurate.
+    * Large φ_zpf (fluxonium, φ_zpf ≳ 1): set ``use_full_cos=True`` to avoid
+      truncation errors.  See arXiv:2411.15039.
+    * Non-cosine or flux-biased junction: use ``non_linear_potential=make_nonlinear_potential(V)``.
+
+    Examples
+    --------
+    Fluxonium with exact cosine:
+
+    >>> f_ND, chi_ND = epr_numerical_diagonalization(
+    ...     freqs, Ljs, phi_zpf, fock_trunc=25, use_full_cos=True
+    ... )
+
+    Flux-biased junction at φ_ext = π/4:
+
+    >>> import numpy as np
+    >>> phi_ext = np.pi / 4
+    >>> nl = make_nonlinear_potential(lambda phi: np.cos(phi - phi_ext),
+    ...                               phi_min=phi_ext)
+    >>> f_ND, chi_ND = epr_numerical_diagonalization(
+    ...     freqs, Ljs, phi_zpf, fock_trunc=15, non_linear_potential=nl
+    ... )
     """
 
     freqs, Ljs, ϕzpf = map(np.array, (freqs, Ljs, ϕzpf))
@@ -140,17 +303,48 @@ def black_box_hamiltonian(
     individual=False,
     non_linear_potential=None,
 ):
-    r"""
-    :param fs: Linearized model, H_lin, normal mode frequencies in Hz, length N
-    :param ljs: junction linearized inductances in Henries, length M
-    :param fzpfs: Zero-point fluctuation of the junction fluxes for each mode across each junction,
-                 shape MxJ
-    :return: Hamiltonian in units of Hz (i.e H / h)
-    All in SI units. The ZPF fed in are the generalized, not reduced, flux.
+    r"""Build the EPR Hamiltonian matrix in Fock space.
 
-    Description:
-     Takes the linear mode frequencies, :math:`\omega_m`, and the zero-point fluctuations, ZPFs, and
-     builds the Hamiltonian matrix of :math:`H_{full}`, assuming cos potential.
+    Constructs
+
+    .. math::
+
+        H = H_{\rm lin} + H_{\rm nl}
+          = \sum_m f_m \hat n_m
+            - \sum_j \frac{E_{J,j}}{h}\,{\rm nl}(\hat\varphi_j)
+
+    where :math:`\hat\varphi_j = \sum_m \phi_{\rm zpf,jm} (\hat a_m + \hat a_m^\dag)`
+    (dimensionless reduced phase), and the nonlinear correction ``nl`` defaults to
+    :func:`cos_approx` (:math:`\cos\varphi - 1 + \varphi^2/2`, the Taylor series
+    starting at :math:`\varphi^4`).
+
+    Parameters
+    ----------
+    fs : array-like
+        Linearised normal-mode frequencies in **Hz**, length M.
+    ljs : array-like
+        Junction linearised inductances in **Henries**, length J.
+    fzpfs : array-like
+        Generalised (not reduced) zero-point flux fluctuations in Wb, shape M×J.
+        Internally divided by ``fluxQ = Φ_0/(2π)`` to obtain reduced phases.
+    cos_trunc : int
+        Cosine Taylor-series truncation order (default 5). Ignored when
+        *non_linear_potential* is given.
+    fock_trunc : int
+        Fock-space truncation per mode (default 8).
+    individual : bool
+        If ``True`` return ``[H_lin, H_nl]`` separately instead of their sum.
+    non_linear_potential : callable or None
+        Custom nonlinear potential: ``nl(φ_op: Qobj) -> Qobj``. Must return the
+        correction **beyond the quadratic**, i.e.
+        :math:`V(\varphi) - V(0) - \tfrac12 V''(0)\varphi^2` normalised by
+        :math:`|V''(0)|`. Use :func:`make_nonlinear_potential` to construct this
+        from any scalar Python function.
+
+    Returns
+    -------
+    qutip.Qobj or [qutip.Qobj, qutip.Qobj]
+        Full Hamiltonian H/h in Hz, or [H_lin/h, H_nl/h] when *individual=True*.
     """
     n_modes = len(fs)
     njuncs = len(ljs)

--- a/pyEPR/calcs/hamiltonian.py
+++ b/pyEPR/calcs/hamiltonian.py
@@ -75,6 +75,47 @@ class MatrixOps(object):
         return cos_phi - I + op_cos_arg**2 / 2
 
     @staticmethod
+    def apply_scalar_function(op: Qobj, func) -> Qobj:
+        """Evaluate a real scalar function on a Hermitian operator via eigendecomposition.
+
+        For a Hermitian operator H with real eigenvalues λ_i and eigenvectors |i⟩:
+
+        .. math::
+
+            f(H) = \\sum_i f(\\lambda_i) |i\\rangle\\langle i|
+
+        This lets you evaluate *any* analytic scalar function—not just polynomials or
+        exponentials—as an operator, which is needed for generic junction potentials.
+
+        Parameters
+        ----------
+        op : qutip.Qobj
+            Hermitian operator (e.g., the phase operator φ in Fock space).
+        func : callable
+            Real scalar function ``func(float) -> float``.
+
+        Returns
+        -------
+        qutip.Qobj
+            ``func(op)`` in the same Hilbert space.
+
+        Examples
+        --------
+        >>> import qutip, numpy as np
+        >>> from pyEPR.calcs.hamiltonian import MatrixOps
+        >>> a = qutip.destroy(8)
+        >>> phi = 0.3 * (a + a.dag())
+        >>> cos_phi = MatrixOps.apply_scalar_function(phi, np.cos)
+        """
+        import numpy as np
+        import qutip
+        mat = op.full()
+        evals, evecs = np.linalg.eigh(mat)          # Hermitian → real eigenvalues
+        f_evals = np.vectorize(func)(evals)
+        result = (evecs * f_evals) @ evecs.conj().T  # V @ diag(f) @ V†
+        return qutip.Qobj(result, dims=op.dims)
+
+    @staticmethod
     def cos_approx(x, cos_trunc=5):
         """
         Create a Taylor series matrix approximation of the cosine, up to some order.

--- a/pyEPR/calcs/hamiltonian.py
+++ b/pyEPR/calcs/hamiltonian.py
@@ -17,13 +17,62 @@ from ..toolbox.pythonic import fact
 class MatrixOps(object):
     @staticmethod
     def cos(op_cos_arg: Qobj):
-        """
-        Make cosine operator matrix from argument  op_cos_arg
+        """Exact cosine operator via matrix exponential: (e^{iφ} + e^{-iφ}) / 2.
 
-            op_cos_arg (qutip.Qobj) : argument of the cosine
-        """
+        Parameters
+        ----------
+        op_cos_arg : qutip.Qobj
+            Phase operator φ (Hermitian).
 
+        Returns
+        -------
+        qutip.Qobj
+            cos(φ) as a matrix in Fock space.
+        """
         return 0.5 * ((1j * op_cos_arg).expm() + (-1j * op_cos_arg).expm())
+
+    @staticmethod
+    def cos_full_correction(op_cos_arg: Qobj):
+        """Exact EPR nonlinear correction: cos(φ) - I + φ²/2 (no truncation).
+
+        This is the infinite-order equivalent of :func:`cos_approx`.  In the
+        EPR Hamiltonian the linear eigenfrequencies already account for the
+        harmonic (φ²/2) Josephson energy, so the nonlinear potential that must
+        be subtracted is the remainder:
+
+        .. math::
+
+            H_{\\mathrm{nl}} = -E_J \\bigl[\\cos(\\varphi) - 1 + \\tfrac{\\varphi^2}{2}\\bigr]
+                             = -E_J \\sum_{n\\ge 2} \\frac{(-1)^n \\varphi^{2n}}{(2n)!}
+
+        For weakly anharmonic circuits (transmon, φ_zpf ≲ 0.3) the truncated
+        :func:`cos_approx` is equivalent and faster.  For strongly anharmonic
+        circuits (fluxonium, φ_zpf ≳ 1) use this function to avoid systematic
+        errors from the truncated series.
+
+        Parameters
+        ----------
+        op_cos_arg : qutip.Qobj
+            Phase operator φ (Hermitian), in the full Fock-space tensor product.
+
+        Returns
+        -------
+        qutip.Qobj
+            cos(φ) - I + φ²/2 as a matrix.
+
+        See Also
+        --------
+        cos_approx : Truncated Taylor-series version (faster for small φ_zpf).
+
+        References
+        ----------
+        arXiv:2411.15039 — EPR analysis for very anharmonic superconducting circuits.
+        """
+        import qutip
+        cos_phi = MatrixOps.cos(op_cos_arg)
+        # Build identity in the same tensor-product Hilbert space as op_cos_arg
+        I = qutip.qeye(op_cos_arg.dims[0])
+        return cos_phi - I + op_cos_arg**2 / 2
 
     @staticmethod
     def cos_approx(x, cos_trunc=5):

--- a/pyEPR/core_quantum_analysis.py
+++ b/pyEPR/core_quantum_analysis.py
@@ -497,7 +497,8 @@ class QuantumAnalysis(object):
             stored in ``self.results``.  Set to ``True`` to recompute everything.
         **kwargs
             Forwarded directly to :meth:`analyze_variation` — e.g.
-            ``cos_trunc``, ``fock_trunc``, ``modes``, ``junctions``.
+            ``cos_trunc``, ``fock_trunc``, ``modes``, ``junctions``,
+            ``use_full_cos``.
 
         Returns
         -------
@@ -679,6 +680,7 @@ class QuantumAnalysis(object):
         print_result: bool = True,
         junctions: List = None,
         modes: List = None,
+        use_full_cos: bool = False,
     ):
         """Compute the quantum Hamiltonian parameters for a single variation.
 
@@ -694,7 +696,8 @@ class QuantumAnalysis(object):
             Cosine Taylor expansion order for the Josephson nonlinearity.
             Typical values: 4–8.  Must be set together with ``fock_trunc`` to
             enable numerical diagonalization; if either is ``None``, only
-            perturbation-theory results are computed.
+            perturbation-theory results are computed.  Ignored when
+            ``use_full_cos=True``.
         fock_trunc : int, optional
             Fock space truncation (number of levels per mode).  Typical values:
             5–10.  Memory scales as ``fock_trunc ** n_modes``.
@@ -708,6 +711,12 @@ class QuantumAnalysis(object):
             of a 5-mode simulation).  **Must match the indices used in**
             ``do_EPR_analysis`` — the DataFrame index retains the original mode
             numbers, not a zero-based re-index.  Defaults to all modes.
+        use_full_cos : bool, optional
+            If ``True``, use the exact matrix-exponential cosine
+            ``cos(φ) = (e^{iφ} + e^{-iφ}) / 2`` instead of the truncated Taylor
+            series.  Recommended for strongly anharmonic circuits such as
+            **fluxonium**, where large zero-point phase fluctuations (φ_zpf ≳ 1)
+            make the low-order expansion inaccurate.  Default ``False``.
 
         Returns
         -------
@@ -775,9 +784,14 @@ class QuantumAnalysis(object):
         CHI_O1 = divide_diagonal_by_2(CHI_O1)  # Make the diagonals alpha
 
         # Numerical diag
-        if cos_trunc is not None:
+        if cos_trunc is not None or use_full_cos:
             f1_ND, CHI_ND = epr_numerical_diagonalization(
-                freqs_hfss, Ljs, PHI_zpf, cos_trunc=cos_trunc, fock_trunc=fock_trunc
+                freqs_hfss,
+                Ljs,
+                PHI_zpf,
+                cos_trunc=cos_trunc,
+                fock_trunc=fock_trunc,
+                use_full_cos=use_full_cos,
             )
         else:
             f1_ND, CHI_ND = None, None

--- a/tests/test_full_cosine.py
+++ b/tests/test_full_cosine.py
@@ -1,0 +1,253 @@
+"""
+Tests for the full-cosine (exact matrix-exponential) diagonalization path,
+relevant for strongly anharmonic circuits like fluxonium.
+
+Physics note
+------------
+In the EPR Hamiltonian, the linear eigenfrequencies already account for the
+harmonic (φ²/2) Josephson energy.  The nonlinear potential that is subtracted
+is therefore the CORRECTION beyond quadratic:
+
+    H_nl = -Ej * [cos(φ) - 1 + φ²/2]
+         = -Ej * Σ_{n≥2} (-1)^n φ^{2n} / (2n)!
+
+``cos_approx`` truncates this series.  ``cos_full_correction`` = cos(φ) - I + φ²/2
+computes it exactly via matrix exponential — no truncation error.
+
+Using the full cosine cos(φ) itself as the nonlinear potential would be WRONG
+because it would double-count the harmonic term already in H_lin.
+
+All tests run without Ansys.
+
+Reference: arXiv:2411.15039 — EPR analysis for very anharmonic circuits.
+"""
+import numpy as np
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _transmon_params():
+    """Transmon-like params: phi_zpf ≈ 0.15 (weakly anharmonic)."""
+    freqs = np.array([5.0])       # GHz
+    Ljs   = np.array([10e-9])     # H
+    phi_zpf = np.array([[0.15]])  # shape (n_modes, n_junctions)
+    return freqs, Ljs, phi_zpf
+
+
+def _fluxonium_params():
+    """Fluxonium-like params: phi_zpf ≈ 2.0 (strongly anharmonic)."""
+    freqs = np.array([0.5])       # GHz
+    Ljs   = np.array([500e-9])    # H
+    phi_zpf = np.array([[2.0]])
+    return freqs, Ljs, phi_zpf
+
+
+# ── smoke tests ───────────────────────────────────────────────────────────────
+
+class TestFullCosineSmoke:
+    def test_truncated_cos_runs(self):
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _transmon_params()
+        f_ND, chi_ND = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, cos_trunc=8, fock_trunc=9
+        )
+        assert f_ND is not None and chi_ND is not None
+
+    def test_full_cos_flag_runs(self):
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _transmon_params()
+        f_ND, chi_ND = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=9, use_full_cos=True
+        )
+        assert f_ND is not None and chi_ND is not None
+
+    def test_full_cos_returns_finite_values(self):
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _transmon_params()
+        f_ND, chi_ND = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=9, use_full_cos=True
+        )
+        assert np.all(np.isfinite(np.real(f_ND)))
+        assert np.all(np.isfinite(np.real(chi_ND)))
+
+    def test_full_cos_fluxonium_runs(self):
+        """Full cosine must not crash for large phi_zpf (fluxonium regime)."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _fluxonium_params()
+        f_ND, chi_ND = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=20, use_full_cos=True
+        )
+        assert np.all(np.isfinite(np.real(f_ND)))
+        assert np.all(np.isfinite(np.real(chi_ND)))
+
+
+# ── convergence: small phi_zpf → high-order truncated ≈ full ─────────────────
+
+class TestFullCosConvergence:
+    """For small phi_zpf, high-order truncated series converges to exact result."""
+
+    def test_transmon_freqs_agree_high_trunc(self):
+        """cos_trunc=16 and use_full_cos should agree to <0.1% for transmon."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _transmon_params()
+        f_trunc, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, cos_trunc=16, fock_trunc=15
+        )
+        f_full, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=15, use_full_cos=True
+        )
+        np.testing.assert_allclose(
+            np.real(f_full), f_trunc, rtol=1e-3,
+            err_msg="High-order truncated and full cosine should agree for transmon",
+        )
+
+    def test_transmon_chi_agree_high_trunc(self):
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _transmon_params()
+        _, chi_trunc = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, cos_trunc=16, fock_trunc=15
+        )
+        _, chi_full = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=15, use_full_cos=True
+        )
+        np.testing.assert_allclose(
+            np.real(chi_full), chi_trunc, rtol=1e-2,
+            err_msg="High-order truncated and full cosine chi should agree for transmon",
+        )
+
+    def test_low_trunc_differs_from_full(self):
+        """Low truncation order gives inaccurate results even for transmon."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _transmon_params()
+        _, chi_low = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, cos_trunc=4, fock_trunc=15
+        )
+        _, chi_full = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=15, use_full_cos=True
+        )
+        # At 4th order there should be a measurable difference (even for small phi_zpf)
+        diff = abs(np.real(chi_full[0, 0]) - chi_low[0, 0])
+        assert diff > 0, "cos_trunc=4 should differ from full cosine"
+
+
+# ── large phi_zpf: truncated series diverges, full cosine converges ───────────
+
+class TestFullCosFluxonium:
+    def test_fluxonium_freqs_differ_from_low_trunc(self):
+        """Low truncation gives wrong frequencies for fluxonium (phi_zpf~2)."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _fluxonium_params()
+        f_low, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, cos_trunc=4, fock_trunc=25
+        )
+        f_full, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=25, use_full_cos=True
+        )
+        max_rel_diff = np.max(np.abs(np.real(f_full) - f_low) / np.abs(np.real(f_full)))
+        assert max_rel_diff > 0.01, (
+            f"Expected large disagreement for fluxonium at cos_trunc=4; "
+            f"got only {max_rel_diff:.4f} relative diff"
+        )
+
+    def test_fluxonium_anharmonicity_sign(self):
+        """Fluxonium anharmonicity (chi[0,0]) should be positive (red shift convention)."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs, Ljs, phi_zpf = _fluxonium_params()
+        _, chi_full = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=25, use_full_cos=True
+        )
+        assert np.real(chi_full[0, 0]) > 0, "Fluxonium anharmonicity should be positive"
+
+
+# ── MatrixOps.cos and cos_full_correction unit tests ─────────────────────────
+
+class TestMatrixOpsCos:
+    def test_cos_zero_is_identity(self):
+        """cos(0) = I."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        n = 5
+        zero_op = qutip.qzero(n)
+        result = MatrixOps.cos(zero_op)
+        np.testing.assert_allclose(result.full(), np.eye(n), atol=1e-12)
+
+    def test_cos_is_hermitian(self):
+        """cos(H) is Hermitian when H is Hermitian."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(8)
+        H = 0.3 * (a + a.dag())
+        result = MatrixOps.cos(H)
+        assert (result - result.dag()).norm() < 1e-10
+
+    def test_cos_agrees_with_numpy_on_diagonal(self):
+        """For a diagonal operator, cos should match numpy.cos element-wise."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        angles = np.linspace(0, np.pi, 5)
+        diag_op = qutip.Qobj(np.diag(angles))
+        result = MatrixOps.cos(diag_op).full().real
+        np.testing.assert_allclose(result, np.diag(np.cos(angles)), atol=1e-10)
+
+    def test_cos_full_correction_zero_is_zero(self):
+        """cos(0) - I + 0²/2 = I - I + 0 = 0."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        zero_op = qutip.qzero(6)
+        result = MatrixOps.cos_full_correction(zero_op)
+        np.testing.assert_allclose(result.full(), np.zeros((6, 6)), atol=1e-12)
+
+    def test_cos_full_correction_is_hermitian(self):
+        """cos_full_correction(H) is Hermitian when H is Hermitian."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(8)
+        H = 0.5 * (a + a.dag())
+        result = MatrixOps.cos_full_correction(H)
+        assert (result - result.dag()).norm() < 1e-10
+
+    def test_cos_full_correction_matches_series_small_arg(self):
+        """cos(x) - I + x²/2 should match high-order cos_approx for small x."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(10)
+        x = 0.1 * (a + a.dag())
+        full = MatrixOps.cos_full_correction(x)
+        approx = MatrixOps.cos_approx(x, cos_trunc=12)
+        np.testing.assert_allclose(full.full(), approx.full(), atol=1e-8)
+
+
+# ── flag behaviour ────────────────────────────────────────────────────────────
+
+class TestFullCosFlag:
+    def test_use_full_cos_produces_different_result_than_low_trunc(self):
+        """use_full_cos=True differs from cos_trunc=4 at moderate phi_zpf."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        freqs = np.array([3.0])
+        Ljs   = np.array([20e-9])
+        phi_zpf = np.array([[0.8]])  # moderate — series converges slowly
+        _, chi_low = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, cos_trunc=4, fock_trunc=12
+        )
+        _, chi_full = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=12, use_full_cos=True
+        )
+        assert abs(np.real(chi_full[0, 0]) - chi_low[0, 0]) > 0
+
+    def test_explicit_non_linear_potential_overrides_use_full_cos(self):
+        """Explicit non_linear_potential takes precedence over use_full_cos flag."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization
+        from pyEPR.calcs.hamiltonian import MatrixOps
+
+        freqs, Ljs, phi_zpf = _transmon_params()
+        f_full, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=9, use_full_cos=True
+        )
+        # Pass the same function explicitly — should give identical result
+        f_explicit, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=9,
+            non_linear_potential=MatrixOps.cos_full_correction,
+            use_full_cos=True,  # flag ignored because non_linear_potential is set
+        )
+        np.testing.assert_allclose(np.real(f_full), np.real(f_explicit), rtol=1e-10)

--- a/tests/test_generic_potential.py
+++ b/tests/test_generic_potential.py
@@ -1,0 +1,276 @@
+"""
+Tests for make_nonlinear_potential — generic scalar potential API.
+
+Physics background
+------------------
+In the EPR Hamiltonian H = H_lin + H_nl, H_lin already encodes the harmonic
+(quadratic) Josephson energy via the linearised inductance Lj.  The nonlinear
+correction that must be added is
+
+    nl(δφ) = [V(φ_min + δφ) - V(φ_min) - V''(φ_min)/2 · δφ²] / |V''(φ_min)|
+
+For the standard Josephson junction V(φ) = cos(φ), φ_min = 0:
+    V(0) = 1, V''(0) = -1  →  nl(δφ) = cos(δφ) - 1 + δφ²/2
+
+which is exactly cos_full_correction.  make_nonlinear_potential recovers this
+automatically for any valid V.
+
+All tests run without Ansys.
+"""
+import numpy as np
+import pytest
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _transmon_params():
+    return np.array([5.0]), np.array([10e-9]), np.array([[0.15]])
+
+
+def _fluxonium_params():
+    return np.array([0.5]), np.array([500e-9]), np.array([[2.0]])
+
+
+# ── MatrixOps.apply_scalar_function ──────────────────────────────────────────
+
+class TestApplyScalarFunction:
+    def test_cos_matches_matrix_exponential(self):
+        """apply_scalar_function(phi, np.cos) should equal MatrixOps.cos(phi)."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(8)
+        phi = 0.3 * (a + a.dag())
+        via_expm = MatrixOps.cos(phi)
+        via_eig  = MatrixOps.apply_scalar_function(phi, np.cos)
+        np.testing.assert_allclose(via_eig.full(), via_expm.full(), atol=1e-10)
+
+    def test_identity_function_returns_operator(self):
+        """apply_scalar_function(H, lambda x: x) should be a no-op."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(6)
+        phi = 0.4 * (a + a.dag())
+        result = MatrixOps.apply_scalar_function(phi, lambda x: x)
+        np.testing.assert_allclose(result.full(), phi.full(), atol=1e-12)
+
+    def test_constant_function_gives_scaled_identity(self):
+        """apply_scalar_function(H, lambda x: 3.0) should be 3·I."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(5)
+        phi = 0.2 * (a + a.dag())
+        result = MatrixOps.apply_scalar_function(phi, lambda x: 3.0)
+        np.testing.assert_allclose(result.full(), 3.0 * np.eye(5), atol=1e-12)
+
+    def test_hermitian_preserved(self):
+        """f(H) is Hermitian when H is Hermitian and f is real."""
+        import qutip
+        from pyEPR.calcs.hamiltonian import MatrixOps
+        a = qutip.destroy(8)
+        phi = 0.5 * (a + a.dag())
+        result = MatrixOps.apply_scalar_function(phi, np.cos)
+        assert (result - result.dag()).norm() < 1e-10
+
+
+# ── make_nonlinear_potential: basic physics ───────────────────────────────────
+
+class TestMakeNonlinearPotentialPhysics:
+    def test_cosine_matches_cos_full_correction(self):
+        """make_nonlinear_potential(cos) must agree with cos_full_correction.
+
+        Both compute the same mathematical object via different numerical paths
+        (eigendecomposition vs. matrix exponential), so we allow ~1 ppm tolerance.
+        """
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential, cos_full_correction
+        a = qutip.destroy(10)
+        phi = 0.4 * (a + a.dag())
+        nl_generic = make_nonlinear_potential(np.cos)(phi)
+        nl_exact   = cos_full_correction(phi)
+        np.testing.assert_allclose(nl_generic.full(), nl_exact.full(), atol=1e-6)
+
+    def test_zero_operator_gives_zero(self):
+        """nl(0) = V(phi_min+0) - V(phi_min) - 0 = 0 for any V."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        nl = make_nonlinear_potential(np.cos)
+        zero_op = qutip.qzero(6)
+        result = nl(zero_op)
+        np.testing.assert_allclose(result.full(), np.zeros((6, 6)), atol=1e-12)
+
+    def test_result_is_hermitian(self):
+        """nl(H) must be Hermitian when H is Hermitian."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        a = qutip.destroy(8)
+        phi = 0.5 * (a + a.dag())
+        nl = make_nonlinear_potential(np.cos)
+        result = nl(phi)
+        assert (result - result.dag()).norm() < 1e-10
+
+    def test_leading_term_is_quartic(self):
+        """For small φ, nl ≈ φ⁴/24; the quadratic term is subtracted by construction.
+
+        We verify this by comparing nl with the leading φ⁴ approximation on the
+        diagonal of the phase operator (where comparison is exact).
+        """
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        # Diagonal phase operator: eigenvalues are just the diagonal entries
+        angles = np.array([0.0, 0.05, 0.1, 0.15, 0.2])
+        diag_op = qutip.Qobj(np.diag(angles))
+        nl = make_nonlinear_potential(np.cos)
+        result = nl(diag_op).full().real
+        # Expected: cos(x) - 1 + x^2/2 evaluated at each diagonal
+        expected = np.diag(np.cos(angles) - 1 + angles**2 / 2)
+        # Tolerance accounts for finite-difference error in V'' estimation (~eps^2~1e-9)
+        np.testing.assert_allclose(result, expected, atol=1e-7)
+        # Verify leading term really is phi^4/24 (no phi^2 contribution)
+        x = angles[2]  # x = 0.1
+        leading = x**4 / 24
+        actual = np.cos(x) - 1 + x**2 / 2
+        np.testing.assert_allclose(actual, leading, rtol=0.01)  # 1% — cos6 term is small
+
+    def test_normalisation_independent_of_overall_scale(self):
+        """Scaling V by a constant must not change nl (Ej_eff absorbs it)."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        a = qutip.destroy(8)
+        phi = 0.3 * (a + a.dag())
+        nl1 = make_nonlinear_potential(np.cos)(phi)
+        nl2 = make_nonlinear_potential(lambda x: 3.0 * np.cos(x))(phi)
+        np.testing.assert_allclose(nl1.full(), nl2.full(), atol=1e-8)
+
+    def test_invalid_phi_min_raises(self):
+        """V''(phi_min) ≈ 0 should raise ValueError."""
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        # V(phi) = phi has V''=0 everywhere
+        with pytest.raises(ValueError, match="quadratic extremum"):
+            make_nonlinear_potential(lambda phi: phi, phi_min=0.0)
+
+
+# ── flux-biased junction ──────────────────────────────────────────────────────
+
+class TestFluxBiasedJunction:
+    """
+    For V(phi) = cos(phi - phi_ext) biased at phi_min = phi_ext,
+    nl should match the unbiased cosine nl because the expansion at the
+    minimum is always cos(delta_phi).
+    """
+
+    def test_biased_matches_unbiased_at_minimum(self):
+        """cos(φ - φ_ext) expanded at φ_ext == cos(δφ) expanded at 0."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        phi_ext = 0.4
+        a = qutip.destroy(10)
+        # The phase fluctuation operator (small ZPF)
+        phi_op = 0.15 * (a + a.dag())
+        nl_unbiased = make_nonlinear_potential(np.cos, phi_min=0.0)(phi_op)
+        nl_biased   = make_nonlinear_potential(
+            lambda phi: np.cos(phi - phi_ext), phi_min=phi_ext
+        )(phi_op)
+        np.testing.assert_allclose(nl_biased.full(), nl_unbiased.full(), atol=1e-8)
+
+    def test_biased_half_flux_is_sin_correction(self):
+        """At phi_ext = pi/2, V(phi)=cos(phi - pi/2)=sin(phi); nl is well-defined."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        phi_ext = np.pi / 2
+        a = qutip.destroy(8)
+        phi_op = 0.15 * (a + a.dag())
+        nl = make_nonlinear_potential(
+            lambda phi: np.cos(phi - phi_ext), phi_min=phi_ext
+        )
+        result = nl(phi_op)
+        assert np.all(np.isfinite(result.full()))
+        assert (result - result.dag()).norm() < 1e-10
+
+
+# ── asymmetric SQUID ──────────────────────────────────────────────────────────
+
+class TestAsymmetricSQUID:
+    """
+    Asymmetric SQUID at external flux phi_ext, asymmetry d = (Ej1-Ej2)/(Ej1+Ej2):
+        V(phi) = cos(phi)*cos(phi_ext) + d*sin(phi)*sin(phi_ext)
+
+    The effective Josephson energy is Ej_eff = Ej_total * |V''(phi_min)|.
+    At d=0 this reduces to a symmetric SQUID; at phi_ext=0 it reduces to a JJ.
+    """
+
+    def test_d0_matches_standard_cosine(self):
+        """Symmetric SQUID (d=0) at phi_ext=0 → standard cos correction."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential, cos_full_correction
+        phi_ext, d = 0.0, 0.0
+        def V_squid(phi):
+            return np.cos(phi) * np.cos(phi_ext) + d * np.sin(phi) * np.sin(phi_ext)
+        phi_min = 0.0  # minimum of -Ej*V_squid at phi_ext=0, d=0
+
+        a = qutip.destroy(10)
+        phi_op = 0.2 * (a + a.dag())
+        nl_squid = make_nonlinear_potential(V_squid, phi_min=phi_min)(phi_op)
+        nl_std   = cos_full_correction(phi_op)
+        np.testing.assert_allclose(nl_squid.full(), nl_std.full(), atol=1e-7)
+
+    def test_asymmetric_squid_returns_finite_hermitian(self):
+        """Asymmetric SQUID at moderate bias gives finite, Hermitian result."""
+        import qutip
+        from pyEPR.calcs.back_box_numeric import make_nonlinear_potential
+        phi_ext, d = 0.3, 0.1
+        def V_squid(phi):
+            return np.cos(phi) * np.cos(phi_ext) + d * np.sin(phi) * np.sin(phi_ext)
+        # phi_min: maximum of V_squid (i.e., minimum of -Ej*V_squid)
+        phi_min = np.arctan(-d * np.tan(phi_ext)) % np.pi
+
+        a = qutip.destroy(10)
+        phi_op = 0.2 * (a + a.dag())
+        nl = make_nonlinear_potential(V_squid, phi_min=phi_min)(phi_op)
+        assert np.all(np.isfinite(nl.full()))
+        assert (nl - nl.dag()).norm() < 1e-10
+
+
+# ── end-to-end via epr_numerical_diagonalization ─────────────────────────────
+
+class TestEndToEndGenericPotential:
+    def test_generic_cos_matches_builtin_use_full_cos(self):
+        """make_nonlinear_potential(cos) passed as non_linear_potential must
+        give the same result as use_full_cos=True."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization, make_nonlinear_potential
+        freqs, Ljs, phi_zpf = _transmon_params()
+        nl = make_nonlinear_potential(np.cos)
+        f_generic, chi_generic = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=15, non_linear_potential=nl
+        )
+        f_builtin, chi_builtin = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=15, use_full_cos=True
+        )
+        # Both methods compute the same quantity via different floating-point paths;
+        # eigendecomposition vs. matrix exponential differ at ~1e-7 level.
+        np.testing.assert_allclose(np.real(f_generic), np.real(f_builtin), rtol=1e-6)
+        np.testing.assert_allclose(np.real(chi_generic), np.real(chi_builtin), rtol=1e-4)
+
+    def test_fluxonium_generic_returns_finite(self):
+        """make_nonlinear_potential works for large phi_zpf (fluxonium regime)."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization, make_nonlinear_potential
+        freqs, Ljs, phi_zpf = _fluxonium_params()
+        nl = make_nonlinear_potential(np.cos)
+        f_ND, chi_ND = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=20, non_linear_potential=nl
+        )
+        assert np.all(np.isfinite(np.real(f_ND)))
+        assert np.all(np.isfinite(np.real(chi_ND)))
+
+    def test_fluxonium_generic_matches_use_full_cos(self):
+        """Generic cos potential and use_full_cos=True must agree for fluxonium."""
+        from pyEPR.calcs.back_box_numeric import epr_numerical_diagonalization, make_nonlinear_potential
+        freqs, Ljs, phi_zpf = _fluxonium_params()
+        nl = make_nonlinear_potential(np.cos)
+        f_gen, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=20, non_linear_potential=nl
+        )
+        f_full, _ = epr_numerical_diagonalization(
+            freqs, Ljs, phi_zpf, fock_trunc=20, use_full_cos=True
+        )
+        # Both use eigendecomposition — should be machine-precision identical
+        np.testing.assert_allclose(np.real(f_gen), np.real(f_full), rtol=1e-8)


### PR DESCRIPTION
Adds full-cosine (matrix-exponential) diagonalization path for fluxonium
and other circuits where phi_zpf ≳ 1 causes the truncated Taylor series
to diverge. Implements cos(φ) − I + φ²/2 (the exact EPR nonlinear
correction) via MatrixOps.cos_full_correction, wired through
epr_numerical_diagonalization(use_full_cos=True) and
analyze_variation(use_full_cos=True). 17 new tests cover smoke, convergence,
and physics correctness. Ref: arXiv:2411.15039.

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5