### PR TITLE
fix: add pandoc to RTD build so tutorial notebooks render on docs site

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+  apt_packages:
+    - pandoc
 
 # Build documentation in the docs/source/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
nbsphinx requires `pandoc` to convert notebook Markdown cells to RST. Without it the tutorials page at https://pyepr-docs.readthedocs.io/en/latest/tutorials.html shows headings but no notebook content.

Fix: add `pandoc` to `apt_packages` in `.readthedocs.yml`. RTD will install it at build time automatically.

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_