### PR TITLE
docs + ci: PyData theme, cards landing page, notebook gallery, CI matrix, image fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ pyEPR — Energy-Participation-Ratio Framework
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/zlatko-minev/pyEPR/master?filepath=_tutorial_notebooks%2FTutorial%206.%20EPR%20without%20HFSS%20%E2%80%94%20purely%20numerical%20workflow.ipynb)
 [![Open Source](https://badges.frapsoft.com/os/v1/open-source.png?v=103)](https://github.com/zlatko-minev/pyEPR)
 
+<p align="center">
+  <img width="80%" src="https://raw.githubusercontent.com/zlatko-minev/pyEPR/master/imgs/read_me_0.png" alt="HFSS field simulation: cavity E-field mode and qubit current-density mode">
+</p>
+
 **pyEPR** bridges classical EM simulation and quantum circuit theory via the
 [energy-participation ratio (EPR)](https://arxiv.org/abs/2010.00620) method.
 Given a 3-D HFSS eigenmode simulation — or your own frequencies and inductances —
@@ -194,7 +198,7 @@ The EPR method requires each Josephson junction to be modelled as a **lumped RLC
 5. Use `Mixed Order` solutions for best accuracy.
 
 <p align="center">
-  <img width="50%" src="imgs/xmon-example.gif" alt="Junction setup example">
+  <img width="50%" src="https://raw.githubusercontent.com/zlatko-minev/pyEPR/master/imgs/xmon-example.gif" alt="Junction setup example">
 </p>
 
 For a full walkthrough, see [Tutorial 1](https://github.com/zlatko-minev/pyEPR/blob/master/_tutorial_notebooks/Tutorial%201.%20%20Startup%20example.ipynb) and the [HFSS setup guide](https://pyepr-docs.readthedocs.io/en/latest/hfss_setup.html) in the docs.

--- a/docs/source/_tutorial_notebooks
+++ b/docs/source/_tutorial_notebooks
@@ -1,0 +1,1 @@
+/home/user/pyEPR/_tutorial_notebooks

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,8 +28,6 @@ import pyEPR
 version = pyEPR.__version__
 release = version
 
-import sphinx_rtd_theme
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -44,15 +42,13 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx.ext.mathjax",
-    "sphinx_rtd_theme",
-    "sphinx_tabs.tabs",
-    "IPython.sphinxext.ipython_directive",
-    "IPython.sphinxext.ipython_console_highlighting",
+    "sphinx_design",
+    "myst_nb",
     "matplotlib.sphinxext.plot_directive",
-    "nbsphinx",
 ]
 
-nbsphinx_execute = 'never'
+nb_execution_mode = "off"   # use saved outputs, never re-execute
+myst_enable_extensions = ["colon_fence", "dollarmath"]
 
 # https://github.com/readthedocs/readthedocs.org/issues/2569
 master_doc = "index"
@@ -87,41 +83,24 @@ napoleon_use_admonition_for_notes = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"  #'default' # 'sphinx_rtd_theme' #'alabaster' "sphinxdoc" 'classic'
-if 0:
-    import os
+html_theme = "pydata_sphinx_theme"
 
-    on_rtd = os.environ.get("READTHEDOCS") == "True"
-    if on_rtd:
-        html_theme = "default"
-    else:
-        html_theme = "nature"
-
-# -- Options for HTML output ----------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = "sphinx_rtd_theme"
-full_logo = True
-
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
 html_theme_options = {
-    "canonical_url": "",
-    #'logo_only': False,
-    "display_version": False,
-    "prev_next_buttons_location": "bottom",
-    "style_external_links": False,
-    #'style_nav_header_background': 'white',
-    # Toc options
-    "collapse_navigation": False,
-    "sticky_navigation": True,
-    "navigation_depth": 4,
-    "includehidden": True,
-    "titles_only": False,
+    "github_url": "https://github.com/zlatko-minev/pyEPR",
+    "use_edit_page_button": False,
+    "show_toc_level": 2,
+    "navbar_align": "left",
+    "navbar_end": ["navbar-icon-links"],
+    "secondary_sidebar_items": ["page-toc"],
+    "footer_start": ["copyright"],
+    "footer_end": ["sphinx-version"],
+    "icon_links": [
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/pyEPR-quantum/",
+            "icon": "fa-solid fa-box",
+        },
+    ],
 }
 # Add any paths that contain custom themes here, relative to this directory.
 
@@ -180,7 +159,7 @@ numfig_format = {"table": "Table %s"}
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/hfss_setup.rst
+++ b/docs/source/hfss_setup.rst
@@ -46,6 +46,11 @@ Typical components:
 Step 3 — Define junction rectangles and polylines
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. image:: _static/xmon-example.gif
+   :width: 70%
+   :alt: Xmon junction setup in HFSS — rectangle and polyline
+   :align: center
+
 Each Josephson junction requires two HFSS objects:
 
 **Junction rectangle**

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,108 +14,88 @@ pyEPR — Energy-Participation-Ratio Framework
 ----
 
 **pyEPR** is an open-source Python library for the automated design and
-quantization of Josephson quantum circuits.  It bridges classical distributed
+quantization of Josephson quantum circuits. It bridges classical distributed
 microwave simulation (Ansys HFSS) and quantum circuit Hamiltonians using the
 `energy-participation ratio (EPR) <https://arxiv.org/abs/2010.00620>`_ method.
 
-What pyEPR does
-===============
+.. grid:: 3
+   :gutter: 3
+   :margin: 4 4 0 0
 
-pyEPR has two main layers:
+   .. grid-item-card:: :octicon:`rocket;1.5em` Simulate
+      :text-align: center
 
-1. **EPR / quantum analysis** *(platform-independent)*
-   Extracts energy-participation ratios from HFSS eigenmode field solutions,
-   then performs numerical diagonalization (via `QuTiP <https://qutip.org>`_)
-   to yield qubit frequencies, anharmonicities, dispersive shifts (χ), and
-   cross-Kerr couplings — all in one automated pipeline.
+      Run an eigenmode simulation in Ansys HFSS with junction inductances.
+      No manual circuit diagram needed — just the 3-D geometry.
 
-2. **Ansys HFSS COM interface** *(Windows-first; see* :ref:`install-platform` *)*
-   A Python wrapper around the HFSS COM/DCOM automation API.  Controls
-   simulation setup, field extraction, and optimetric sweeps directly from
-   Python.  Originally written before `PyAEDT <https://github.com/ansys/pyaedt>`_
-   existed; the two tools are complementary — pyEPR for quantum EPR analysis,
-   PyAEDT for general AEDT scripting.
+   .. grid-item-card:: :octicon:`graph;1.5em` Extract
+      :text-align: center
+
+      Compute energy participation ratios *p*\ :sub:`mj` and zero-point
+      phase fluctuations φ\ :sub:`zpf` for every mode and junction.
+
+   .. grid-item-card:: :octicon:`beaker;1.5em` Diagonalize
+      :text-align: center
+
+      Numerically diagonalize the full Josephson Hamiltonian to get
+      dressed frequencies, anharmonicities, and the χ matrix.
+
+----
 
 Quick install
 =============
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: uv *(recommended)*
-
-      .. code-block:: bash
-
-         uv pip install pyEPR-quantum
-
-   .. tab:: pip
+   .. tab-item:: pip
 
       .. code-block:: bash
 
          pip install pyEPR-quantum
 
-   .. tab:: conda
+   .. tab-item:: conda
 
       .. code-block:: bash
 
          conda install -c conda-forge pyepr-quantum
 
-See :ref:`install` for full instructions including development installs,
-platform notes, and Ansys version compatibility.
+   .. tab-item:: uv
 
-Quick-start example
-===================
+      .. code-block:: bash
 
-The following script connects to HFSS, extracts EPR data, and produces the
-full Hamiltonian for a two-qubit / one-cavity chip in a few lines of code.
+         uv pip install pyEPR-quantum
+
+No Ansys licence? Start with :ref:`without-hfss` or open
+`Tutorial 6 on Binder <https://mybinder.org/v2/gh/zlatko-minev/pyEPR/master?filepath=_tutorial_notebooks%2FTutorial%206.%20EPR%20without%20HFSS%20%E2%80%94%20purely%20numerical%20workflow.ipynb>`_.
+
+----
+
+Five-line quickstart
+====================
 
 .. code-block:: python
 
    import pyEPR as epr
 
-   # 1. Connect to HFSS project
-   pinfo = epr.ProjectInfo(
-       project_path = r'C:\sim_folder',
-       project_name = r'cavity_with_two_qubits',
-       design_name  = r'Alice_Bob',
-   )
-
-   # 2. Specify Josephson junctions
-   pinfo.junctions['jAlice'] = {
-       'Lj_variable': 'Lj_alice', 'rect': 'rect_alice',
-       'line': 'line_alice', 'Cj_variable': 'Cj_alice',
-   }
-   pinfo.junctions['jBob'] = {
-       'Lj_variable': 'Lj_bob', 'rect': 'rect_bob',
-       'line': 'line_bob', 'Cj_variable': 'Cj_bob',
-   }
-   pinfo.validate_junction_info()
-
-   # 3. Run EPR field extraction
+   pinfo = epr.ProjectInfo(project_path=r'C:\sims', project_name='my_chip',
+                            design_name='qubit_cavity')
+   pinfo.junctions['jQ'] = {'Lj_variable':'Lj1', 'rect':'junc_rect',
+                             'line':'junc_line', 'Cj_variable':'Cj1'}
    eprd = epr.DistributedAnalysis(pinfo)
    eprd.do_EPR_analysis()
-
-   # 4. Quantum Hamiltonian diagonalization
    epra = epr.QuantumAnalysis(eprd.data_filename)
-   epra.analyze_all_variations(cos_trunc=8, fock_trunc=7)
-   epra.plot_hamiltonian_results(swp_variable='Lj_alice')
+   epra.analyze_all_variations(cos_trunc=8, fock_trunc=15)
 
-See the `Jupyter notebook tutorials
-<https://github.com/zlatko-minev/pyEPR/tree/master/_tutorial_notebooks>`_
-for step-by-step walkthroughs.
+See the :doc:`examples_quick` page for more complete examples including the
+no-HFSS numerical workflow.
 
-
-.. image:: _static/xmon-example.gif
-   :width: 70%
-   :alt: Xmon example
-   :align: center
-
+----
 
 Contents
 ========
 
 .. toctree::
    :maxdepth: 2
-   :numbered:
 
    about.rst
    installation.rst
@@ -127,7 +107,7 @@ Contents
    key_classes_reference.rst
 
 .. toctree::
-   :caption: API Reference:
+   :caption: API Reference
    :glob:
    :hidden:
 
@@ -139,4 +119,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,11 @@ microwave simulation (Ansys HFSS) and quantum circuit Hamiltonians using the
       Numerically diagonalize the full Josephson Hamiltonian to get
       dressed frequencies, anharmonicities, and the χ matrix.
 
+.. image:: _static/xmon-example.gif
+   :width: 55%
+   :alt: HFSS junction setup animation — Xmon qubit
+   :align: center
+
 ----
 
 Quick install

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -4,12 +4,28 @@ Tutorial Notebooks
 ==================
 
 These tutorials are Jupyter notebooks that can be run interactively.
-Tutorials 3, 5, and 6 require only ``pip install pyEPR-quantum``;
-Tutorials 1, 2, and 4 require a live Ansys HFSS session.
+Tutorials 3, 5, and 6 require only ``pip install pyEPR-quantum``
+and run entirely without Ansys HFSS.
+
+.. grid:: 1
+   :gutter: 2
+
+   .. grid-item-card:: Tutorial 3 — Circuit QED Parameters
+
+      E_J, E_C, L_J, I_c conversions; transmon model. **No HFSS required.**
+
+   .. grid-item-card:: Tutorial 5 — Generic Junction Potential & Fluxonium
+
+      Exact cosine diagonalization for fluxonium; custom V(φ); asymmetric SQUIDs. **No HFSS required.**
+
+   .. grid-item-card:: Tutorial 6 — EPR without HFSS
+
+      Supply freqs, Ljs, φ_zpf directly. Full χ matrix without any EM solver. **No HFSS required.**
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
-   ../../_tutorial_notebooks/Tutorial 3.  toolbox_circuits
-   ../../_tutorial_notebooks/Tutorial 5. Generic junction potential and fluxonium EPR
-   ../../_tutorial_notebooks/Tutorial 6. EPR without HFSS — purely numerical workflow
+   _tutorial_notebooks/Tutorial 3.  toolbox_circuits
+   _tutorial_notebooks/Tutorial 5. Generic junction potential and fluxonium EPR
+   _tutorial_notebooks/Tutorial 6. EPR without HFSS — purely numerical workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ include = ["pyEPR*"]
 [project.optional-dependencies]
 docs = [
     "sphinx>=4.0",
-    "sphinx-rtd-theme>=0.4.0",
-    "sphinx-tabs>=3.4.0",
-    "nbsphinx",
+    "pydata-sphinx-theme",
+    "sphinx-design",
+    "myst-nb",
 ]
 test = [
     "pytest>=7.0",


### PR DESCRIPTION
## Summary

### Docs modernization
- **PyData Sphinx Theme** replaces `sphinx-rtd-theme` (same theme as NumPy, pandas, SciPy, QuTiP — improves legitimacy and navigation)
- **sphinx-design cards** on `index.rst` landing page: 3-column grid (Simulate / Extract / Diagonalize) + tab-set install options
- **myst-nb** replaces `nbsphinx` + `sphinx-tabs`; `nb_execution_mode = "off"` uses saved outputs without re-executing
- **Notebook gallery** on `tutorials.rst`: sphinx-design cards for Tutorials 3, 5, 6 (no-HFSS track)
- **Hero images** on landing page: `read_me_0.png` (cavity/qubit field simulation) + `xmon-example.gif` below the cards; xmon GIF also added to `hfss_setup.rst` Step 3
- **PyPI image fix**: `imgs/` relative paths → `raw.githubusercontent.com` absolute URLs so images render on PyPI (not just GitHub)

### README overhaul
- Adoption-first structure with hero image, quickstart (no Ansys), full HFSS workflow, tutorial table
- Physically correct transmon parameters in quickstart (EJ/h=20 GHz, EC/h=300 MHz → freq=6.928 GHz, Lj=8.2 nH, φ_zpf=0.416)
- "Who uses pyEPR" section preserved

### CI matrix
- `{ubuntu-latest, macos-latest} × {Python 3.10, 3.12}` (was single Python 3.9)
- `fail-fast: false`, `-q` quiet flag; pylint and docs jobs on Python 3.12

### Other fixes
- `pandoc` added to RTD build so myst-nb renders notebook Markdown on ReadTheDocs
- Browser/search title: removed version number (`"Welcome to pyEPR! — Energy-Participation-Ratio Framework"`)
- `language = None` → `"en"` (Sphinx deprecation)
- `pyproject.toml`: `requires-python = ">=3.10, <4"`, updated [docs] extras

## Test plan

- [ ] CI passes on all 4 matrix combinations (ubuntu+macos × 3.10+3.12)
- [ ] `test_docs` job builds docs with 0 errors
- [ ] Check PyPI badge renders hero image after merge + PyPI publish
- [ ] Verify ReadTheDocs build picks up PyData theme and notebook gallery

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_