### PR TITLE
docs: fix About page badges; slim Key Classes page; reorder TOC

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -1,16 +1,12 @@
 About pyEPR
 ===========
 
-.. |Open Source Love| image:: https://badges.frapsoft.com/os/v1/open-source.png?v=103
-   :target: https://github.com/zlatko-minev/pyEPR
-.. |Awesome| image:: https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
-   :target: https://github.com/zlatko-minev/pyEPR
 .. |star this repo| image:: https://img.shields.io/github/stars/zlatko-minev/pyEPR?style=social
    :target: https://github.com/zlatko-minev/pyEPR/stargazers
 .. |fork this repo| image:: https://img.shields.io/github/forks/zlatko-minev/pyEPR?style=social
    :target: https://github.com/zlatko-minev/pyEPR/fork
 
-|Open Source Love| |Awesome| |star this repo| |fork this repo|
+:bdg-success:`Open Source — BSD-3` :bdg-info:`Python 3.10+` |star this repo| |fork this repo|
 
 .. contents:: On this page
    :local:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,12 +104,12 @@ Contents
 
    about.rst
    installation.rst
+   key_classes_reference.rst
    hfss_setup.rst
    examples_quick.rst
    without_hfss.rst
    tutorials.rst
    troubleshooting.rst
-   key_classes_reference.rst
 
 .. toctree::
    :caption: API Reference

--- a/docs/source/key_classes_reference.rst
+++ b/docs/source/key_classes_reference.rst
@@ -1,5 +1,5 @@
-Key classes reference
-=====================
+Key Classes
+===========
 
 .. contents:: On this page
    :local:
@@ -18,7 +18,7 @@ onto the three stages of the EPR analysis pipeline:
         ▼
    QuantumAnalysis        — quantize: load HDF5, diagonalize Hamiltonian, report results
 
-These classes are all importable from the top-level ``pyEPR`` namespace:
+All three are importable from the top-level ``pyEPR`` namespace:
 
 .. code-block:: python
 
@@ -56,10 +56,7 @@ Key attributes:
    pinfo.setup              # HfssSetup wrapper (eigenmode or driven-modal)
    pinfo.design             # HfssDesign wrapper
 
-.. autoclass:: pyEPR.project_info.ProjectInfo
-   :members:
-   :show-inheritance:
-   :no-index:
+Full API: :class:`pyEPR.project_info.ProjectInfo`
 
 
 .. _distributed-analysis:
@@ -87,10 +84,7 @@ Key methods:
    eprd.hfss_report_full_convergence()# print/plot adaptive-pass convergence
    eprd.data_filename                 # path to the saved HDF5 results file
 
-.. autoclass:: pyEPR.core_distributed_analysis.DistributedAnalysis
-   :members:
-   :show-inheritance:
-   :no-index:
+Full API: :class:`pyEPR.core_distributed_analysis.DistributedAnalysis`
 
 
 .. _quantum-analysis:
@@ -126,33 +120,24 @@ Key methods:
   size grows as ``fock_trunc ** n_modes``, so keep this small for
   many-mode systems.  Typical range: 6–10.
 
-.. autoclass:: pyEPR.core_quantum_analysis.QuantumAnalysis
-   :members:
-   :show-inheritance:
-   :no-index:
+Full API: :class:`pyEPR.core_quantum_analysis.QuantumAnalysis`
 
 
 solution_types module
 ---------------------
 
-``pyEPR.solution_types`` is a utility module exposing canonical solution-type
-constants and helpers.  Import from here rather than using raw strings.
+``pyEPR.solution_types`` exposes canonical solution-type constants and
+helpers for handling the AEDT 2021.2+ renamed solution-type strings:
 
 .. code-block:: python
 
    from pyEPR.solution_types import normalize, DRIVEN_MODAL_NAMES, is_drivenmodal
 
-   normalize("HFSS Modal Network")    # → "DrivenModal"
-   normalize("HFSS Hybrid Terminal Network")  # → "DrivenTerminal"
-   is_drivenmodal("HFSS Modal Network")  # → True
+   normalize("HFSS Modal Network")           # → "DrivenModal"
+   normalize("HFSS Hybrid Terminal Network") # → "DrivenTerminal"
+   is_drivenmodal("HFSS Modal Network")      # → True
 
-This module is also useful for downstream tools (e.g. Qiskit Metal) that need
-to handle the AEDT 2021.2+ renamed solution-type strings.
-
-.. automodule:: pyEPR.solution_types
-   :members:
-   :show-inheritance:
-   :no-index:
+Full API: :mod:`pyEPR.solution_types`
 
 
 calcs subpackage


### PR DESCRIPTION
## Summary

- **`about.rst`** — replace broken `frapsoft.com` (Open Source Love) and `rawgit.com` (Awesome, site is dead) badge image refs with sphinx-design `:bdg-success:` / `:bdg-info:` inline badges; keep the GitHub stars/forks shields.io badges which are reliable
- **`key_classes_reference.rst`** — strip the `autoclass`/`automodule` directives (they were redundant with `api/` pages and suppressed with `:no-index:` anyway); replace with `:class:` / `:mod:` cross-reference links; page is now a lightweight onboarding narrative rather than a duplicate API mirror
- **`index.rst`** — move "Key Classes" immediately after "Installation" in the sidebar TOC (it's a getting-started page, not a reference appendix)

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_