### PR TITLE
bump version to 0.9.6

### DIFF
--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -90,7 +90,7 @@ __credits__ = [
     "Steven Touzard",
 ]
 __license__ = "BSD-3-Clause"
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 __maintainer__ = "Zlatko K. Minev and  Asaf Diringer"
 __email__ = "zlatko.minev@aya.yale.edu"
 __url__ = r"https://github.com/zlatko-minev/pyEPR"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bumps `__version__` from `0.9.5` → `0.9.6`
- Captures all documentation modernization work from PRs #199–203 that landed after the `0.9.5` tag

## What's in 0.9.6

- **PyData Sphinx Theme** — replaces sphinx-rtd-theme (consistent with NumPy/SciPy/QuTiP)
- **sphinx-design** — hero image, feature cards, install tabs, HFSS/no-HFSS badges
- **myst-nb** — replaces nbsphinx; notebook gallery with `nb_execution_mode = "off"`
- **Tutorials page** — all 6 tutorials in order with clickable cards
- **RTD + CI fix** — pre-build notebook copy step (Sphinx won't follow symlinks outside source root)
- **Zero-warning Sphinx build** — down from 177 warnings
- **README** — absolute raw.githubusercontent.com image URLs (renders correctly on PyPI)
- **About page** — replaced dead badge URLs with sphinx-design badges

## Test plan

- [ ] CI passes (pylint + pytest + docs build)
- [ ] After merge: create GitHub Release tag `v0.9.6` → triggers publish-to-pypi.yml OIDC publish

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_