### PR TITLE
docs(agent): expand CLAUDE.md and add /health-check slash command

### DIFF
--- a/.claude/commands/docstring-audit.md
+++ b/.claude/commands/docstring-audit.md
@@ -1,0 +1,196 @@
+# /docstring-audit
+
+Systematically audit and improve docstrings across the pyEPR codebase. Work
+module by module. For each module, check coverage, style, and accuracy —
+then fix what you can safely fix (pure text changes, no logic changes).
+
+After completing each module, run the docs build to confirm zero new warnings
+were introduced before moving to the next module.
+
+---
+
+## Style standard
+
+All public methods in `core_*.py`, `project_info.py`, and `calcs/` must use
+**NumPy-style docstrings**. The structure is:
+
+```python
+def example(self, x, y=None):
+    """One-line summary, ending with a period.
+
+    Optional extended description. Explain *why* non-obvious constraints exist,
+    not *what* the code does (the code already shows that).
+
+    Parameters
+    ----------
+    x : float
+        Description of x, including units if physical (e.g. "Junction
+        inductance in henries.").
+    y : int, optional
+        Description of y. Default is None, which means ...
+
+    Returns
+    -------
+    result : np.ndarray, shape (n_modes, n_junctions)
+        Description of the return value, including shape/dtype when relevant.
+
+    Raises
+    ------
+    ValueError
+        If x is negative.
+
+    Notes
+    -----
+    Any mathematical context or derivation references go here. Use
+    :math:`...` for inline LaTeX and `.. math::` for display equations.
+
+    Examples
+    --------
+    >>> example(1.0, y=2)
+    array([...])
+    """
+```
+
+---
+
+## RST pitfalls to avoid while writing docstrings
+
+Read `.claude/context/lessons-learned.md` first. The most common failures:
+
+- `|x⟩` bra-ket notation → use `:math:`|x\\rangle``
+- `**kwargs` in paragraphs → wrap in `` ``**kwargs`` ``
+- `----` separator lines → use NumPy section headers instead
+- First line indented relative to `"""` → start on the same line as `"""`
+- Duplicate class in both narrative RST and `api/` → use cross-reference in narrative
+
+---
+
+## Module priority order
+
+Work through modules in this order. Higher priority = more user-facing.
+
+### Priority 1 — `calcs/` subpackage
+
+These are the most user-facing for the no-HFSS audience. Pure math, no COM.
+
+```bash
+python -m pydocstyle pyEPR/calcs/ --convention=numpy 2>&1 | head -40
+```
+
+Check each module:
+- `calcs/basic.py` — general EM and qubit parameter formulas
+- `calcs/transmon.py` — transmon charge-basis diagonalization
+- `calcs/convert.py` — unit conversion helpers
+- `calcs/hamiltonian.py` — Hamiltonian matrix construction
+- `calcs/back_box_numeric.py` — numerical black-box diagonalization
+- `calcs/constants.py` — physical constants (usually just needs a module docstring)
+
+For each function/class: does it have a docstring? Is the Parameters section
+complete? Does it describe units? Is there a Returns section?
+
+After editing each file:
+```bash
+rm -rf docs/source/_tutorial_notebooks
+cp -r _tutorial_notebooks docs/source/_tutorial_notebooks
+cd docs && make html 2>&1 | grep -c WARNING
+# Must still be 0
+```
+
+### Priority 2 — `project_info.py`
+
+This is the user's first touch point — they configure `ProjectInfo` before
+anything else. Its docstrings are the most important for onboarding.
+
+Check:
+- Class docstring explains what `ProjectInfo` is and its role in the pipeline.
+- `__init__` documents every parameter including `project_path`, `project_name`,
+  `design_name`, and `setup_name`.
+- `junctions` attribute: document the dict schema
+  (`{name: {'Lj_variable': str, 'rect': str, 'line': str, 'Cj_variable': str}}`).
+  Misconfigured junctions are the most common user error.
+- `dissipative` attribute: document the dict keys
+  (`dielectrics_bulk`, `dielectric_surfaces`, `resistive_surfaces`, `seams`).
+
+### Priority 3 — `core_quantum_analysis.py`
+
+This is the post-processing half that runs without HFSS. Used heavily by
+the no-HFSS audience.
+
+Check key methods:
+- `analyze_all_variations()` — most important method. Document `cos_trunc`,
+  `fock_trunc` parameters with their typical ranges and what each controls.
+- `report_results()` — document `swp_variable` and `numeric` parameters.
+- `plot_hamiltonian_results()` — document what is plotted.
+- `get_Pmj()` — document return shape.
+
+### Priority 4 — `core_distributed_analysis.py`
+
+The HFSS-dependent half. Lower priority for the no-HFSS audience, but
+important for HFSS users.
+
+Check key methods:
+- `do_EPR_analysis()` — the main entry point. Document what it does, what
+  it saves, and where.
+- `calc_p_junction()` — document the physical meaning of the return value.
+
+Do not add docstrings to private methods (leading `_`) unless they are
+complex enough to warrant it.
+
+### Priority 5 — `toolbox/`
+
+Lower priority. Check for missing module docstrings and class docstrings.
+
+---
+
+## Checking coverage
+
+```bash
+# List all public functions/classes missing docstrings
+python -c "
+import ast, sys
+from pathlib import Path
+
+def check_file(path):
+    src = path.read_text()
+    tree = ast.parse(src)
+    missing = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not node.name.startswith('_'):
+                if not (node.body and isinstance(node.body[0], ast.Expr)
+                        and isinstance(node.body[0].value, ast.Constant)):
+                    missing.append(f'{path}:{node.lineno} {node.name}')
+    return missing
+
+for p in sorted(Path('pyEPR').rglob('*.py')):
+    if '__pycache__' in str(p):
+        continue
+    for m in check_file(p):
+        print(m)
+" 2>/dev/null | grep -v ansys.py | head -50
+```
+
+Work through the list starting from `calcs/` and `project_info.py`.
+
+---
+
+## What not to do
+
+- Do not add docstrings to `ansys.py` COM methods without human review.
+  The parameter names and types in COM calls are version-sensitive and
+  a wrong docstring is worse than no docstring.
+- Do not change method signatures while adding docstrings.
+- Do not add `Examples` sections that require Ansys HFSS — they will not
+  run in doctests and will mislead users.
+- Do not add `.. automethod::` directives to narrative RST pages — they
+  duplicate API pages and cause duplicate-object warnings.
+
+---
+
+## Reporting
+
+After completing each module, report:
+- Module name
+- Number of functions/classes updated
+- Any warnings that appeared in the docs build (should be zero)
+- Any docstrings you skipped and why

--- a/.claude/commands/health-check.md
+++ b/.claude/commands/health-check.md
@@ -1,0 +1,170 @@
+# /health-check
+
+Perform a systematic maintenance and health audit of the pyEPR repository. Work through each section below in order. For each item: check the current state, report what you find, fix anything clearly broken, and flag anything that needs human judgment (especially anything touching Ansys/HFSS COM code).
+
+At the end, produce a prioritised punch list: what was fixed, what needs attention, and what was skipped and why.
+
+---
+
+## 1. Docs build — zero warnings required
+
+```bash
+rm -rf docs/source/_tutorial_notebooks
+cp -r _tutorial_notebooks docs/source/_tutorial_notebooks
+cd docs && make html 2>&1 | tee /tmp/sphinx_build.log
+grep -c "WARNING\|ERROR" /tmp/sphinx_build.log
+```
+
+- If warning count > 0: read each warning and fix it before proceeding. Common causes are listed in CLAUDE.md under "RST / docstring pitfalls".
+- Check that all six tutorial notebooks appear in `tutorials.rst` and render without toctree warnings.
+- Check that the landing page (`index.rst`) hero image and xmon GIF render — both require absolute `_static/` paths, not symlinks.
+- Verify `docs/source/conf.py` extensions list matches what's installed in `[docs]` extras in `pyproject.toml`. Any `Unknown directive` or `No module named` error means a mismatch.
+
+## 2. Test suite — baseline must hold
+
+```bash
+pytest -q 2>&1 | tail -20
+```
+
+- Zero failures, zero errors on the non-HFSS suite. If anything is failing, it is a blocker — fix it before anything else.
+- Check that `@pytest.mark.hfss` tests are properly skipped (not erroring). Run `pytest -q --co -m hfss` to list them; they should show as collected but never run in CI.
+- Review `tests/` for tests that call into `ansys.py` without the `hfss` mark — this would cause silent failures for users without Ansys. Add the mark if missing.
+- Check `tests/correct_results.pkl` and `tests/data*.npz` — if any are missing from the repo, the numerical regression tests will silently pass vacuously.
+
+## 3. Dependency health
+
+```bash
+pip install -e ".[test]"
+python -W error::DeprecationWarning -m pytest tests/ -q 2>&1 | grep -i deprecat | head -20
+```
+
+- Fix any DeprecationWarnings that come from pyEPR's own code (not from third-party libraries).
+- Check `pyproject.toml` for version pins. The following are intentional and should not be changed without explicit review:
+  - Any upper-bound pin on a scientific library (numpy, scipy, pandas) — these exist because upstream broke something.
+- Verify that the package installs cleanly on Python 3.10 and 3.12:
+  ```bash
+  python --version  # check current
+  python -c "import pyEPR; print(pyEPR.__version__)"
+  ```
+- Check for any import of `win32com`, `pythoncom`, or `pywintypes` at the top level of any module outside `ansys.py`. These are Windows-only and will break Linux/macOS installs.
+
+## 4. API stability
+
+```bash
+python -c "
+import pyEPR as epr
+# All of these must import without error or DeprecationWarning
+_ = epr.ProjectInfo
+_ = epr.DistributedAnalysis
+_ = epr.QuantumAnalysis
+_ = epr.Project_Info          # deprecated alias
+_ = epr.pyEPR_HFSSAnalysis    # deprecated alias
+_ = epr.pyEPR_Analysis        # deprecated alias
+from pyEPR.solution_types import normalize, DRIVEN_MODAL_NAMES, is_drivenmodal
+print('All public API imports OK')
+"
+```
+
+- If any alias raises `ImportError` or `AttributeError`, fix it — downstream packages depend on them.
+- Check that `solution_types` is importable independently without triggering COM imports:
+  ```bash
+  python -c "import sys; import pyEPR.solution_types; print([m for m in sys.modules if 'win32' in m or 'ansys' in m.lower()])"
+  # should print []
+  ```
+
+## 5. README and PyPI rendering
+
+- Open `README.md` and check every image URL. Images must use absolute `https://raw.githubusercontent.com/zlatko-minev/pyEPR/master/...` URLs — relative paths do not render on PyPI.
+- Check that the xmon GIF and any other media files referenced in README actually exist in the `imgs/` directory.
+- Verify the PyPI badge URLs (shields.io) are well-formed and point to the correct package name (`pyEPR-quantum`, not `pyepr` or `pyEPR`).
+- Check that `docs/source/about.rst` has no dead image URLs (frapsoft.com and rawgit.com are known-dead badge hosts — replace with sphinx-design badges if found).
+
+## 6. Version and release consistency
+
+```bash
+python -c "import pyEPR; print(pyEPR.__version__)"
+grep 'version' pyproject.toml
+git tag --list | sort -V | tail -5
+```
+
+- `__version__` in `pyEPR/__init__.py` must match the most recent git tag.
+- `pyproject.toml` should read version dynamically: `dynamic = ["version"]` with `[tool.setuptools.dynamic] version = {attr = "pyEPR.__version__"}`. If it's hardcoded, flag this — version drift between the two is a real release bug.
+- Check that `CHANGELOG.md` (if it exists) has an entry for the current version.
+- Check the GitHub Releases page (via `gh release list` or MCP tool) to confirm the latest release tag points to a commit that has the matching `__version__`. A tag on the wrong commit publishes the wrong version to PyPI.
+
+## 7. CI workflow correctness
+
+Read `.github/workflows/ci.yaml` and check:
+
+- The `test_docs` job includes the notebook copy step before `make html`:
+  ```yaml
+  - name: Copy tutorial notebooks into docs source
+    run: |
+      rm -rf docs/source/_tutorial_notebooks
+      cp -r _tutorial_notebooks docs/source/_tutorial_notebooks
+  ```
+  If this step is missing, the docs CI job will report false-pass with toctree warnings.
+- The `test` job matrix covers at least Python 3.10 and 3.12 on Ubuntu and macOS.
+- The `pylint` job uses `--errors-only` (not full report) to keep CI signal-to-noise ratio high.
+- The `publish-to-pypi.yml` workflow triggers on `release: created` (not `push`). If it triggers on push, it will attempt to publish on every commit.
+
+## 8. Tutorials and onboarding experience
+
+```bash
+ls _tutorial_notebooks/
+```
+
+- All six tutorial notebooks must be present: Tutorials 1–6.
+- Tutorials 3, 5, and 6 are the no-HFSS path — these are the onboarding notebooks for users without Ansys. Check that they run correctly:
+  ```bash
+  jupyter nbconvert --to notebook --execute \
+    --ExecutePreprocessor.timeout=120 \
+    "_tutorial_notebooks/Tutorial 6. EPR without HFSS — purely numerical workflow.ipynb"
+  ```
+- Check that Tutorial 6 has a working Binder badge in `docs/source/tutorials.rst`. The URL should point to the correct branch (`master`) and notebook path.
+- Check that `docs/source/without_hfss.rst` exists and accurately describes the no-HFSS workflow. This is the primary landing page for users without Ansys licences and must be kept current.
+
+## 9. Ecosystem compatibility
+
+```bash
+pip show pyEPR-quantum | grep Version
+```
+
+- Check the current version against what quantum-metal (formerly qiskit-metal) declares as its minimum: `pyEPR-quantum >= 0.9.5`. If pyEPR's current version is behind this, users of quantum-metal on older pyEPR will get import errors.
+- Run a quick compatibility smoke test:
+  ```python
+  from pyEPR.solution_types import normalize, DRIVEN_MODAL_NAMES, is_drivenmodal
+  from pyEPR import ProjectInfo, DistributedAnalysis, QuantumAnalysis
+  # These are the imports quantum-metal uses
+  ```
+- If any of the above fail, that is a breaking change for downstream users — treat as P0.
+
+## 10. Code hygiene
+
+```bash
+# Check for remaining print() calls in analysis code (not ansys.py, not toolbox)
+grep -rn "^\s*print(" pyEPR/ --include="*.py" \
+  | grep -v ansys.py | grep -v toolbox/ | grep -v __pycache__ | grep -v ".pyc"
+```
+
+- Any `print()` in `core_distributed_analysis.py`, `core_quantum_analysis.py`, `project_info.py`, or `calcs/` should be converted to `logger.info()` / `logger.warning()`.
+- Check for bare `except:` clauses (should be `except Exception:` or more specific).
+- Check for any `TODO` or `FIXME` comments that reference a specific version or issue that has since been resolved.
+
+---
+
+## Reporting format
+
+After completing all checks, report in this format:
+
+### Fixed
+- [item] — what was wrong, what was changed
+
+### Needs attention (flag for human)
+- [item] — what was found, why human judgment is needed (especially anything touching HFSS/Ansys or public API)
+
+### Clean
+- [item] — checked, no action needed
+
+### Skipped
+- [item] — why (e.g. requires live HFSS session, requires PyPI access, etc.)

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,181 @@
+# /release
+
+Walk through the full pyEPR release process for the next version. Work through
+each step in order and do not skip steps, even if they seem already done.
+
+---
+
+## Step 1 — Confirm readiness
+
+Before touching any version numbers, verify the codebase is clean:
+
+```bash
+# All non-HFSS tests pass
+pytest -q
+
+# Docs build with zero warnings
+rm -rf docs/source/_tutorial_notebooks
+cp -r _tutorial_notebooks docs/source/_tutorial_notebooks
+cd docs && make html 2>&1 | grep -c WARNING
+# Must print 0
+
+# No uncommitted changes
+git status
+```
+
+If anything fails, stop and fix it first. A release with a broken test suite
+or broken docs is worse than no release.
+
+## Step 2 — Determine the new version number
+
+```bash
+python -c "import pyEPR; print('Current version:', pyEPR.__version__)"
+git tag --list | sort -V | tail -5
+```
+
+Decide the new version following these rules:
+- **Patch** (`0.9.x → 0.9.x+1`): bug fixes, documentation updates, dependency
+  compatibility fixes, CI improvements. No new features, no deprecations.
+- **Minor** (`0.9.x → 0.10.0`): new public API (additive), new tutorials,
+  significant documentation overhaul. Should not break any existing user code.
+- **Major** (`0.9.x → 1.0.0`): reserved for architectural changes that may
+  break existing workflows.
+
+When in doubt, use a patch release. It is always safe to release patch versions
+frequently.
+
+## Step 3 — Summarise changes since last release
+
+```bash
+# Find the commit SHA of the last release tag
+git log --oneline $(git tag --list | sort -V | tail -1)..HEAD
+```
+
+Group the commits into categories for the release notes:
+- New features
+- Bug fixes
+- Documentation
+- CI / packaging
+- Dependency compatibility
+
+Draft release notes. Format (markdown, for GitHub Releases body):
+
+```markdown
+## What's new in X.Y.Z
+
+### Bug fixes
+- ...
+
+### Documentation
+- ...
+
+### CI / packaging
+- ...
+
+### Dependencies
+- ...
+```
+
+## Step 4 — Bump the version
+
+The version lives in exactly one place: `pyEPR/__init__.py`. `pyproject.toml`
+reads it dynamically — do not edit `pyproject.toml`.
+
+```python
+# pyEPR/__init__.py — find this line and change the version:
+__version__ = "X.Y.Z"
+```
+
+Verify the dynamic read works:
+```bash
+python -c "import pyEPR; print(pyEPR.__version__)"
+# Must print the new version
+```
+
+## Step 5 — Commit and open a PR
+
+```bash
+git checkout -b release/vX.Y.Z
+git add pyEPR/__init__.py
+git commit -m "bump version to X.Y.Z"
+git push -u origin release/vX.Y.Z
+```
+
+Open a PR titled `bump version to X.Y.Z`. The PR body should include the
+release notes drafted in Step 3 (reviewers need to know what they are approving).
+
+Wait for CI to pass (pylint, pytest, docs build). Do not merge if any CI job fails.
+
+## Step 6 — Merge the PR
+
+After CI passes and any review is complete, merge the PR to master.
+
+Confirm the merge landed:
+```bash
+git fetch origin master
+git log --oneline origin/master -3
+python -c "
+import subprocess, sys
+result = subprocess.run([sys.executable, '-c',
+    'import importlib.util; spec = importlib.util.spec_from_file_location(\"pyEPR\", \"pyEPR/__init__.py\"); m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); print(m.__version__)'],
+    capture_output=True, text=True)
+print(result.stdout.strip())
+"
+```
+
+## Step 7 — Create the GitHub Release
+
+Use the GitHub MCP tool or the GitHub web UI. Key requirements:
+- **Tag:** `vX.Y.Z` (with the `v` prefix, e.g. `v0.9.6`)
+- **Target:** must point to the master commit that has the bumped `__version__`
+- **Release title:** `pyEPR vX.Y.Z`
+- **Body:** the release notes from Step 3
+- **Not a pre-release** (unless intentionally releasing a beta)
+
+The `publish-to-pypi.yml` GitHub Actions workflow triggers automatically on
+`release: created` and publishes to PyPI via OIDC Trusted Publishing. No API
+token is needed.
+
+## Step 8 — Verify the PyPI publish
+
+Wait 3–5 minutes, then:
+
+```bash
+pip index versions pyEPR-quantum 2>/dev/null | head -3
+# or
+curl -s https://pypi.org/pypi/pyEPR-quantum/json | python -c "import sys,json; d=json.load(sys.stdin); print(list(d['releases'].keys())[-5:])"
+```
+
+The new version must appear. If it does not appear after 10 minutes:
+- Check the `publish-to-pypi.yml` Actions run for errors.
+- Common issue: the tag was created on the wrong commit (before the version bump).
+  If this happened, the wheel was built with the old `__version__`. You must
+  yank the release on PyPI and redo from Step 6.
+
+## Step 9 — Post-release check
+
+```bash
+# Verify clean install from PyPI
+pip install pyEPR-quantum==X.Y.Z
+python -c "import pyEPR; print(pyEPR.__version__)"
+# Must print X.Y.Z
+
+# Verify the no-HFSS import path still works
+python -c "
+from pyEPR.solution_types import normalize, DRIVEN_MODAL_NAMES
+from pyEPR import ProjectInfo, QuantumAnalysis
+from pyEPR.calcs.transmon import transmon_get_spectrum_charge_basis
+print('All imports OK')
+"
+```
+
+If anything fails at this stage, file a hotfix immediately — users are now
+installing the broken version.
+
+## Step 10 — Update downstream if needed
+
+If this release contains a breaking change (rare) or a significant new feature
+that downstream packages should adopt:
+- Check quantum-metal's `pyproject.toml` for their `pyEPR-quantum >= X.Y.Z` pin.
+- If their minimum is now outdated, consider opening an issue or PR on quantum-metal
+  to update their minimum version. Do not do this silently.

--- a/.claude/context/ecosystem.md
+++ b/.claude/context/ecosystem.md
@@ -1,0 +1,187 @@
+# Ecosystem, Adoption, and Developer Relations Context
+
+Understanding *why* pyEPR exists, who uses it, and what its place in the
+broader quantum computing stack is — this is necessary context for making
+good decisions about API design, documentation, and release timing.
+
+---
+
+## What pyEPR is and is not
+
+**pyEPR is** a post-processing and quantization library. It takes eigenmode
+field simulation results (from Ansys HFSS or any compatible solver) and
+produces quantum Hamiltonian parameters: mode frequencies, anharmonicities,
+dispersive shifts (χ matrix), and zero-point fluctuations.
+
+**pyEPR is not:**
+- A geometry or layout tool — that is quantum-metal (formerly qiskit-metal) or KLayout.
+- A general AEDT scripting library — that is PyAEDT.
+- A circuit simulator — it post-processes distributed-field solutions.
+- An alternative to QuTiP — it uses QuTiP internally for diagonalization.
+
+The distinction matters because feature requests often conflate these roles.
+When someone asks pyEPR to "draw a qubit" or "run a SPICE simulation", the
+answer is "that is not this tool's scope."
+
+---
+
+## The user spectrum
+
+**Group 1: Experimental hardware groups (primary)**
+These are the core users. They have Ansys HFSS licences, they run eigenmode
+simulations of 3D cavities or planar chips, and they use pyEPR to extract
+Hamiltonian parameters. They are physicists first, programmers second.
+Their pain points: COM connection stability, AEDT version compatibility,
+clear error messages when junction parameters are misconfigured.
+
+**Group 2: Theorists and students (high adoption potential)**
+No Ansys licence. They want to run the numerical EPR workflow (Tutorial 6)
+to understand the method, or they load a pre-computed HDF5 file from a
+collaborator. This group is the largest potential audience and the most
+underserved. They are served by: Tutorial 6, `QuantumAnalysis` loaded from
+HDF5, `calcs/` subpackage, Binder links, and headless docs.
+
+**Group 3: Chip design automation users (strategic)**
+Using quantum-metal (formerly qiskit-metal) for layout design and relying
+on pyEPR for the EPR analysis step. These users rarely interact with pyEPR
+directly — quantum-metal calls it internally. They care about: import
+stability, no Windows-only deps on the analysis path, correct pyEPR version
+pinning in quantum-metal's requirements.
+
+---
+
+## The quantum-metal relationship
+
+quantum-metal (PyPI: `quantum-metal`, formerly `qiskit-metal`) is the main
+downstream consumer of pyEPR. It:
+- Declares `pyEPR-quantum >= 0.9.5` as a dependency
+- Imports `pyEPR.solution_types` (must be importable without COM stack)
+- Imports `pyEPR.ProjectInfo`, `pyEPR.DistributedAnalysis`, `pyEPR.QuantumAnalysis`
+- Uses the deprecated aliases `pyEPR_HFSSAnalysis` and `pyEPR_Analysis`
+
+**Constraints this imposes on pyEPR:**
+- Do not remove deprecated aliases. quantum-metal imports them.
+- Do not add Windows-only imports to `solution_types.py` or `calcs/`. quantum-metal
+  runs on Linux/macOS and these modules must import cleanly.
+- Treat any change to the public API of `ProjectInfo`, `DistributedAnalysis`, or
+  `QuantumAnalysis` as potentially breaking for quantum-metal users until
+  quantum-metal ships a new release.
+- When pyEPR releases a new version, quantum-metal's `pyEPR-quantum >= X.Y.Z`
+  pin means users on older pyEPR will still run. Breaking changes in a new
+  pyEPR minor release can be masked for a long time if quantum-metal's minimum
+  is not bumped. Be conservative.
+
+---
+
+## The no-HFSS path — the most important adoption lever
+
+Most researchers who hear about pyEPR are blocked from trying it because they
+assume they need Ansys HFSS. They do not, for a large class of use cases.
+
+The no-HFSS path:
+1. **Tutorial 6** — supply frequencies, junction inductances, and φ_zpf manually;
+   get the full χ matrix back. No EM solver at all.
+2. **`QuantumAnalysis` from HDF5** — if a collaborator runs the HFSS extraction
+   and saves the HDF5 file, the quantum analysis runs anywhere.
+3. **`calcs/` subpackage** — direct formula access. Transmon spectrum, EPR formulas,
+   unit conversions. Pure Python/numpy/scipy.
+
+These paths must be the most polished, best-documented, and most reliably
+tested parts of the codebase. They are the onramp. If Tutorial 6 has a broken
+import or a unit bug, the user's first impression of pyEPR is broken.
+
+**Binder:** Tutorial 6 must have a working Binder badge. Binder allows a new
+user to run the notebook in the browser with zero install. This is the lowest
+possible friction onramp. Keep the badge URL correct and test it periodically;
+Binder builds can fail if the `requirements.txt` or `environment.yml` goes stale.
+
+---
+
+## The documentation philosophy
+
+The docs use the **PyData Sphinx Theme** — the same theme as NumPy, SciPy,
+pandas, and QuTiP. This is intentional: it signals to researchers that
+pyEPR is part of the scientific Python ecosystem they already know. It also
+provides a modern, navigable layout without custom CSS work.
+
+**sphinx-design** provides the visual components: feature cards on the
+landing page, install tabs, HFSS/no-HFSS badges on tutorials. These make
+the docs look maintained and signal capability quickly to a new visitor.
+
+**myst-nb** handles notebook rendering. Notebooks are executed once and
+saved with outputs; myst-nb renders the saved outputs without re-executing
+(`nb_execution_mode = "off"`). This means: the docs always reflect the
+state of the notebook at commit time, and the build does not require Ansys.
+
+**Zero-warning build is non-negotiable.** A docs build with warnings looks
+unmaintained and erodes trust. Every warning is a signal to a potential user
+that the project is not actively cared for.
+
+---
+
+## Docstring and API documentation philosophy
+
+**NumPy-style docstrings** — the standard across NumPy, SciPy, pandas,
+QuTiP, and scikit-learn. Hardware physicists who are already familiar with
+the scientific Python stack will find this immediately readable.
+
+Docstrings should explain:
+- *What* the method does (one-line summary)
+- *Why* non-obvious parameters have their specific constraints or units
+- *What* is returned and in what units/shape
+
+Docstrings should not explain *how* the method is implemented — that
+belongs in comments in the code, and only when the implementation is
+non-obvious.
+
+**API pages** are auto-generated from docstrings via `automodule` in `docs/source/api/`.
+The narrative `key_classes_reference.rst` page should contain *explanation and
+context*, not duplicated API tables. If a class appears in both the narrative
+page and the API page, use a cross-reference link (`:class:`...``) in the
+narrative page, not a redundant `.. autoclass::`.
+
+---
+
+## Release and versioning philosophy
+
+pyEPR follows semantic versioning loosely:
+- Patch releases (`0.9.x`) — bug fixes, documentation, dependency compatibility.
+  Should not break any user code.
+- Minor releases (`0.x.0`) — new features, potentially deprecating old patterns.
+  Deprecated items stay for at least one minor version.
+- Major releases (`x.0.0`) — reserved for significant architectural changes.
+  The current codebase has not had one.
+
+**Release timing:** pyEPR does not have a fixed release cadence. Releases are
+driven by meaningful accumulation of changes: a significant new feature,
+a batch of bug fixes, or a documentation overhaul. Small releases are fine;
+releasing with only a version bump to pick up trivial changes is not useful.
+
+**PyPI publish is automated** via OIDC Trusted Publishing. No API token is
+needed. Create the GitHub Release with the correct tag; the workflow fires
+automatically. Verify on PyPI after ~5 minutes.
+
+---
+
+## What the community cares about
+
+Based on issues, questions, and usage patterns:
+
+1. **AEDT version compatibility** — the most common issue. New AEDT releases
+   change API strings, design creation behaviour, and scripting call signatures.
+   Users upgrade AEDT and pyEPR breaks. This is the highest-friction pain point.
+
+2. **The junction setup** — misconfigured junction rectangles and polylines are
+   the most common user error. Clear error messages when junction parameters are
+   wrong save enormous amounts of support time.
+
+3. **The no-HFSS workflow** — constantly requested by students and theorists.
+   Tutorial 6 is the answer; keep it working.
+
+4. **Import stability** — researchers copy-paste pyEPR code into their own
+   analysis scripts and expect it to continue working across pyEPR updates.
+   The deprecated aliases (`pyEPR_Analysis`, etc.) exist for exactly this reason.
+
+5. **Documentation** — the most consistent feedback on any scientific Python
+   project is "better docs." The PyData theme migration, the tutorial gallery,
+   and the zero-warning build are direct responses to this.

--- a/.claude/context/lessons-learned.md
+++ b/.claude/context/lessons-learned.md
@@ -1,0 +1,226 @@
+# Lessons Learned — Hard-Won Maintenance Knowledge
+
+Every item here caused a real build failure, a silent test pass, a broken
+PyPI page, or a regression for downstream users. Read this before touching
+docs, CI, or anything related to Ansys version compatibility.
+
+---
+
+## Sphinx / Documentation
+
+### Sphinx won't follow symlinks outside its source root
+
+`docs/source/_tutorial_notebooks` is a git symlink pointing to
+`../../_tutorial_notebooks/`. Sphinx silently ignores it — no warning,
+no error, just missing content and toctree "nonexisting document" errors.
+
+**Fix:** Copy before every build. This step is required in three places:
+- Local `make html` (do it manually)
+- `.readthedocs.yml` under `jobs.pre_build`
+- `.github/workflows/ci.yaml` in the `test_docs` job
+
+If you add a new CI job that builds docs, add the copy step. Forgetting
+it produces a false-green CI run (zero errors) because toctree entries
+for missing files are silently dropped, not errored.
+
+### sphinx-design `link-type: doc` silently strips spaces and periods
+
+When using `:link: _tutorial_notebooks/Tutorial 3.  toolbox_circuits`
+with `link-type: doc`, sphinx-design normalises the path by stripping
+spaces and periods, producing `Tutorial3toolbox_circuits` — a path that
+does not exist.
+
+**Fix:** Use `link-type: url` with a relative `.html` path. Browsers
+percent-encode spaces in hrefs automatically:
+```rst
+:link: _tutorial_notebooks/Tutorial 3.  toolbox_circuits.html
+:link-type: url
+```
+
+### Duplicate object description warnings
+
+If a class appears in both `key_classes_reference.rst` (via `.. autoclass::`)
+and in `api/` (via `.. automodule::`), Sphinx emits a duplicate-object warning
+that counts against the zero-warning gate.
+
+**Fix:** Remove `.. autoclass::` from narrative RST files. Replace with a
+plain cross-reference link: `:class:`pyEPR.core_quantum_analysis.QuantumAnalysis``.
+The `api/` automodule page handles the full API documentation.
+
+If removing autoclass is not possible, add `:no-index:` to the second
+occurrence, but prefer the cross-reference approach.
+
+### RST pipe characters in docstrings
+
+`|x⟩` bra-ket notation with a pipe character triggers RST substitution
+reference parsing. The warning is `Substitution_reference "x⟩" not found`
+and the rendered output is broken.
+
+**Fix:** Use `:math:`|x\\rangle`` instead of plain Unicode.
+
+### `**kwargs` in docstring paragraphs
+
+Bare `**` inside a paragraph triggers RST strong emphasis markup.
+`**kwargs` renders as bold `kwargs` and may cause "Inline strong start-string
+without end-string" warnings.
+
+**Fix:** Wrap in double backticks: `` ``**kwargs`` ``.
+
+### Separator lines in docstrings
+
+A line of `----` at the start of a docstring section causes:
+`WARNING: Transition must be child of a section or document`
+
+**Fix:** Use a proper RST section header (underlined with `~` or `-`),
+or remove the separator entirely. The NumPy docstring convention uses
+section headers (`Parameters`, `Returns`, etc.), not horizontal rules.
+
+### Indented first line of docstring
+
+A docstring whose first line is indented relative to the opening `"""`
+creates a block-quote RST node. Sphinx renders it oddly and may warn.
+
+**Fix:** Start the first line immediately after `"""`, at the same
+indentation level as the opening quotes.
+
+### Wrong directive names
+
+- `.. tabs::` / `.. tab::` — from `sphinx-tabs`, which is **not installed**.
+  Use `.. tab-set::` / `.. tab-item::` from `sphinx-design` instead.
+- `.. nbsphinx::` — not installed. Notebooks are handled by `myst-nb`.
+- `..codeblock python` (no space) — silently ignored, not rendered.
+  Must be `.. code-block:: python` with a space before the language.
+
+### `suppress_warnings` in `conf.py`
+
+Some warnings are unavoidable (myst-nb header level conventions, notebook
+syntax highlighting fallbacks). These are suppressed in `conf.py`:
+```python
+suppress_warnings = ["myst.header", "misc.highlighting_failure", "ref.python"]
+```
+Do not add new entries here without first investigating whether the warning
+can be fixed at the source. This list should stay short.
+
+---
+
+## Python / Dependencies
+
+### qutip 5.x — `ket.dag() * ket` returns a scalar, not a 1×1 Qobj
+
+In qutip 4.x, `ket.dag() * ket` returned a 1×1 `Qobj` with a `.norm()` method.
+In qutip 5.x, the same expression returns a complex scalar.
+
+Code that calls `.norm()` or `.tr()` on the result will raise `AttributeError`
+on qutip 5.x.
+
+**Fix:**
+```python
+inner = ket.dag() * ket
+if hasattr(inner, "norm"):   # qutip 4.x
+    val = inner.norm()
+else:                        # qutip 5.x — already a scalar
+    val = abs(inner)
+```
+
+### pandas FutureWarnings
+
+pandas regularly deprecates indexing patterns. The most common offenders:
+- `df.loc[:, col]` vs `df[col]` — silent in old versions, warning in newer
+- `DataFrame.append()` — removed in pandas 2.0; use `pd.concat()`
+- Chained assignment (`df[col][mask] = val`) — use `.loc` instead
+
+Run `python -W error::FutureWarning -m pytest tests/` to surface these.
+
+### numpy 2.x — `np.bool`, `np.int`, `np.float` removed
+
+These aliases were deprecated in numpy 1.20 and removed in 2.0.
+Any code using `np.bool`, `np.int`, or `np.float` directly will raise
+`AttributeError` on numpy 2.x.
+
+The current `pyproject.toml` pins numpy to a range that may not include 2.x.
+Do not lift a numpy upper-bound pin without auditing all such usages first.
+
+### Windows-only imports must stay confined to `ansys.py`
+
+`win32com`, `pythoncom`, and `pywintypes` are Windows-only. If any of these
+appear at the top level of any module outside `ansys.py`, the package will
+fail to import on Linux and macOS — silently, with an `ImportError`.
+
+`solution_types.py` and `calcs/` must never import from `ansys.py` or
+from any Windows-only library. This is a hard constraint: downstream
+packages (quantum-metal) run on Linux and import these modules.
+
+---
+
+## CI / Release
+
+### CI docs job needs the notebook copy step
+
+The `test_docs` CI job initially did not have the notebook copy step, so
+it ran `make html` against a source tree where `_tutorial_notebooks/` was
+an unresolved symlink. The job showed zero errors (Sphinx silently dropped
+missing toctree entries) but the built docs were missing all six tutorials.
+
+**Fix:** The copy step must be in the CI YAML, not only in `.readthedocs.yml`.
+
+### Tag must point to the commit with the bumped version
+
+The PyPI publish workflow reads `__version__` from `pyEPR/__init__.py`
+at the time the wheel is built. If the GitHub Release tag points to a
+commit where `__version__` has not yet been bumped (e.g. the merge commit
+of the feature work, not the version-bump commit), the wheel will carry
+the old version number.
+
+**Correct order:**
+1. Merge all feature PRs
+2. Open and merge a version-bump PR (change only `__version__`)
+3. Create the GitHub Release tag pointing to the post-merge master commit
+
+### Dead badge image URLs
+
+- `frapsoft.com` (Open Source Love badges) — dead, returns 404
+- `rawgit.com/sindresorhus/awesome` — dead CDN, returns 404
+
+Both appeared in `docs/source/about.rst`. Replace with sphinx-design
+inline badges (`:bdg-success:`, `:bdg-info:`, etc.) which have no
+external runtime dependency.
+
+---
+
+## Ansys AEDT version compatibility
+
+### AEDT 2024.1+ silently creates Hybrid Modal Network
+
+`InsertDesign("HFSS", name, "DrivenModal", "")` creates an
+`HFSS Hybrid Modal Network` design on AEDT 2024.1+, not a plain
+`DrivenModal`. The string `"DrivenModal"` is accepted without error
+but the design type is wrong.
+
+**Fix:** Call `SetSolutionType` immediately after `InsertDesign` on
+AEDT >= 2024.1. The helpers `project.new_dm_design()` and
+`project.new_dt_design()` already do this correctly.
+
+### `GetSolutionType` returns new strings on AEDT 2021.2+
+
+AEDT 2021.2 introduced renamed solution-type strings
+(`"HFSS Modal Network"` instead of `"DrivenModal"`). New aliases are
+added with each AEDT release; the old ones are not removed.
+
+**Fix:** Always pass `GetSolutionType()` output through `normalize()`
+from `pyEPR.solution_types` before any string comparison. This is
+already done in `HfssDesign.__init__`. Never add raw string comparisons
+elsewhere.
+
+---
+
+## PyPI / README rendering
+
+### Relative image paths do not render on PyPI
+
+`README.md` is rendered by PyPI's pipeline. Relative paths like
+`imgs/xmon-example.gif` resolve against the local filesystem during
+development but produce broken images on PyPI.
+
+**Fix:** Use absolute `https://raw.githubusercontent.com/zlatko-minev/pyEPR/master/imgs/...`
+URLs for every image in `README.md`. GitHub's raw CDN is reliable and
+renders correctly on both GitHub and PyPI.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ pytest -m hfss
 pylint pyEPR/                    # full report
 pylint --errors-only pyEPR/      # CI mode
 
+# Build docs locally (must copy notebooks first — see Docs section)
+rm -rf docs/source/_tutorial_notebooks
+cp -r _tutorial_notebooks docs/source/_tutorial_notebooks
+cd docs && make html
+# open docs/build/html/index.html
+
 # Build distribution
 pip install build
 python -m build
@@ -77,6 +83,25 @@ All COM objects are accessed via a thin `COMWrapper` base that delegates attribu
 from pyEPR.solution_types import normalize, DRIVEN_MODAL_NAMES, is_drivenmodal
 ```
 
+## Testability boundary
+
+This is the most important constraint for any agent working in this repo.
+
+| Area | Testable in CI | Notes |
+|------|---------------|-------|
+| `calcs/` | Yes | Pure math, numpy/scipy/qutip only |
+| `solution_types.py` | Yes | No external deps |
+| `QuantumAnalysis` (post-HDF5) | Yes | Uses fixtures in `tests/` |
+| `toolbox/` | Yes | Logging, plotting, pandas helpers |
+| `project_info.py` | Yes | Config object, no COM |
+| `ansys.py` | **No** | Requires live Ansys HFSS COM session |
+| `DistributedAnalysis` (field extraction) | **No** | Requires live HFSS solve |
+| `HfssDesign`, `HfssSetup`, etc. | **No** | COM-only |
+
+**Never write a test that calls into `ansys.py` without `@pytest.mark.hfss`.** Tests without that mark run in CI on every PR and will fail without a physical Ansys licence.
+
+For the `ansys.py` code: you can read, reason about, and document it. You can flag logic errors or version-compatibility issues. But do not modify COM-facing behaviour without a human who can validate against a real AEDT session.
+
 ## HFSS version compatibility
 
 Two layers of fixes are required for AEDT compatibility:
@@ -112,24 +137,76 @@ When checking Ansys scripting API for new issues, look at:
 
 The Ansys AEDT scripting guide (IronPython/CPython) is the authoritative source; PyAEDT source code is a useful secondary reference for how they handle the same changes.
 
+## Documentation standards
+
+pyEPR uses the **PyData Sphinx Theme** with `sphinx-design` and `myst-nb`. These were chosen to match the broader scientific Python ecosystem (NumPy, SciPy, pandas, QuTiP) and to support rich landing pages and notebook galleries without requiring Ansys.
+
+### Hard rules
+
+- **Zero warnings on `make html`** — this is a CI gate. Every new docstring, RST file, or notebook added must not introduce warnings. Run `cd docs && make html 2>&1 | grep -c WARNING` before committing docs changes; it must return `0`.
+- **No print() in analysis code** — use `logger = logging.getLogger(__name__)`. The toolbox provides logging helpers.
+- **NumPy-style docstrings** — all public methods in `core_*.py`, `project_info.py`, and `calcs/` must use the NumPy docstring convention (Parameters / Returns / Raises sections).
+
+### Notebook copy step (critical)
+
+Sphinx does not follow symlinks outside its source root. `docs/source/_tutorial_notebooks` is a git symlink to `../../_tutorial_notebooks/`. **Always copy before building:**
+
+```bash
+rm -rf docs/source/_tutorial_notebooks
+cp -r _tutorial_notebooks docs/source/_tutorial_notebooks
+```
+
+This step is required in:
+- Local `make html` (do it manually)
+- `.readthedocs.yml` `pre_build` job
+- `.github/workflows/ci.yaml` `test_docs` job
+
+If you add a new CI job that builds docs, add the copy step.
+
+### RST / docstring pitfalls
+
+These have each caused real build failures. Know them before editing docs or docstrings:
+
+- **Pipe characters in docstrings** — `|x⟩` bra-ket notation triggers RST substitution reference parsing. Use `:math:`|x\\rangle`` instead.
+- **`*args` / `**kwargs` in docstrings** — bare `*` and `**` inside paragraphs trigger RST emphasis markup. Wrap in double backticks or a code block.
+- **Separator lines in docstrings** — a line of `----` at the start of a docstring section triggers "Transition must be child of section" warning. Use a proper RST section header instead.
+- **Indented first lines** — a docstring whose first line is indented relative to the opening `"""` creates a block-quote RST node, which Sphinx renders oddly.
+- **Duplicate object descriptions** — if a class appears in both `key_classes_reference.rst` (via `autoclass`) and `api/` (via `automodule`), Sphinx emits a duplicate-object warning. Use `:no-index:` on one, or replace `autoclass` with a plain cross-reference link (preferred).
+- **Unknown directives** — `.. tabs::` (sphinx-tabs) and `.. tab::` are not installed; the project uses `.. tab-set::` / `.. tab-item::` (sphinx-design). Similarly, `nbsphinx` is not installed; notebooks are handled by `myst-nb`.
+- **`.. code-block::` syntax** — must be `.. code-block:: python` with a space before the language. `..codeblock python` is silently ignored.
+
 ## Release workflow
 
 1. Bump `__version__` in `pyEPR/__init__.py` — `pyproject.toml` reads version dynamically from there.
-2. Commit and push to master (via PR, not direct push).
-3. Create a GitHub Release (tag e.g. `v0.9.4`). The `publish-to-pypi.yml` workflow triggers on `release: created` and uses OIDC Trusted Publishing (no API token needed; configured on PyPI under Trusted Publishers).
-4. Verify the published version on PyPI matches the intended `__version__`. If `__version__` was not bumped before tagging, the wheel will carry the old version.
+2. Commit and push to master via PR (never direct-push to master).
+3. After the PR merges, create a GitHub Release with tag `vX.Y.Z` (e.g. `v0.9.6`). The `publish-to-pypi.yml` workflow triggers on `release: created` and uses OIDC Trusted Publishing — no API token needed.
+4. Verify the published version on PyPI matches `__version__`. If the version was not bumped before tagging, the wheel will carry the wrong version.
 
-CI workflow (`ci.yaml`) runs on every push: pylint (errors-only), pytest (no hfss marker), and docs build.
+CI (`ci.yaml`) runs on every push: pylint (errors-only), pytest (non-HFSS), and docs build.
+
+**The tag must be created on the commit that has the bumped version number.** Create the GitHub Release pointing at master only after the version-bump PR has merged.
 
 ## Backwards compatibility
 
-- All public API must remain stable across minor versions. New helpers like `new_dm_design` / `new_dt_design` are additive; they do not change existing `new_design()` behaviour.
-- `Project_Info`, `pyEPR_HFSSAnalysis`, `pyEPR_Analysis` are deprecated aliases kept in `__init__.py` for backwards compatibility — do not remove them.
-- The `solution_types` module is new (added in 0.9.x) — downstream packages (qiskit-metal) can import from it without importing the full COM stack.
-- When adding new HFSS functionality, always check that the COM calls gracefully handle older AEDT versions where the API may not exist.
+- All public API must remain stable across minor versions. New helpers are additive; they do not change existing behaviour.
+- `Project_Info`, `pyEPR_HFSSAnalysis`, `pyEPR_Analysis` are deprecated aliases kept in `__init__.py` — do not remove them. Downstream packages (including qiskit-metal / quantum-metal) import these.
+- The `solution_types` module was designed so downstream packages can import it without pulling in the COM stack (`import win32com` is Windows-only). Never add a top-level import of COM-related modules to `solution_types.py` or `calcs/`.
+- When adding HFSS functionality, always check that COM calls gracefully handle older AEDT versions where the API may not exist. Guard with `self._ansys_version >= "YYYY.N"` checks.
+
+## Ecosystem context
+
+pyEPR is a dependency of **quantum-metal** (formerly qiskit-metal), IBM's open-source quantum chip design framework. That package declares `pyEPR-quantum >= 0.9.5` in its `pyproject.toml`. Changes to pyEPR's public API, import structure, or `solution_types` module may silently break quantum-metal until their next release — be conservative.
+
+The primary adoption path for users without Ansys is:
+1. Tutorial 6 (`_tutorial_notebooks/`) — numerical EPR without HFSS
+2. `QuantumAnalysis` loaded from a pre-computed HDF5 file
+3. `calcs/` subpackage for direct formula access
+
+These paths must remain importable on Linux and macOS without `win32com` or any Windows-only dependency.
 
 ## Testing notes
 
-- Mark any test requiring a live Ansys HFSS session with `@pytest.mark.hfss` and they will be skipped in CI automatically.
+- Mark any test requiring a live Ansys HFSS session with `@pytest.mark.hfss` — CI skips these automatically.
 - `tests/correct_results.pkl` and `tests/data*.npz` are reference fixtures for numerical regression tests.
 - qutip 5.x changed `ket.dag() * ket` to return a complex scalar instead of a 1×1 Qobj — guard with `hasattr(inner, "norm")` when writing quantum analysis tests.
+- When adding a new feature, add a test that would have caught the most obvious misuse. The test suite is the primary protection against regressions from upstream dependency changes (qutip, numpy, pandas, scipy all release breaking changes).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Agent context — read these before starting work
+
+| File | When to read |
+|------|-------------|
+| `.claude/context/lessons-learned.md` | Before touching docs, CI, Sphinx config, or Ansys version code. Contains every hard-won fix from real build failures and regressions. |
+| `.claude/context/ecosystem.md` | Before changing public API, release timing, imports, or anything that could affect downstream users. Explains who uses pyEPR, the quantum-metal relationship, and the no-HFSS adoption path. |
+
+## Slash commands
+
+| Command | What it does |
+|---------|-------------|
+| `/health-check` | Full 10-section maintenance audit: docs, tests, deps, API stability, README/PyPI, release, CI, tutorials, ecosystem, code hygiene. |
+| `/release` | Step-by-step release workflow: verify readiness → version bump → PR → merge → tag → PyPI → post-release check. |
+| `/docstring-audit` | Module-by-module NumPy docstring audit with priority ordering and RST pitfall reminders. |
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## What this does

Captures the institutional knowledge built up during a full maintenance pass of the repo — docs modernisation, CI fixes, RTD/Binder, release workflow, ecosystem dependencies — into two files any AI agent (or human contributor) can pick up and act on.

### `CLAUDE.md` (expanded)

Adds five new sections to the existing code-level reference:

- **Testability boundary table** — explicit map of what can/cannot run in CI without a live Ansys HFSS session. This is the single most important constraint for any automated agent working in this repo.
- **Documentation standards** — zero-warning rule, the notebook symlink/copy requirement (Sphinx won't follow symlinks outside source root), and a catalogue of RST/docstring pitfalls that have each caused real build failures: pipe characters in bra-ket notation, `**kwargs` emphasis parsing, separator-line transitions, duplicate object descriptions, wrong directive names.
- **Ecosystem context** — quantum-metal (formerly qiskit-metal) declares `pyEPR-quantum >= 0.9.5`; changes to the public API or `solution_types` may silently break it. The no-HFSS import path (`calcs/`, `solution_types`, `QuantumAnalysis` from HDF5) must stay importable on Linux/macOS without `win32com`.
- **Release workflow detail** — the tag-must-match-version invariant: the GitHub Release tag must point to the commit that already has the bumped `__version__`, otherwise PyPI publishes the wrong version.
- **Backwards compatibility guard** — the deprecated aliases (`Project_Info`, `pyEPR_HFSSAnalysis`, `pyEPR_Analysis`) stay; the `solution_types` module must never grow a top-level COM import.

### `.claude/commands/health-check.md`

A `/health-check` slash command for Claude Code. A single invocation runs a 10-section maintenance audit:

1. Docs build — zero warnings
2. Test suite — baseline must hold
3. Dependency health — DeprecationWarnings, version pins, Windows-only imports
4. API stability — all public imports and deprecated aliases
5. README / PyPI rendering — absolute image URLs, badge validity
6. Version and release consistency — `__version__` vs tag vs PyPI
7. CI workflow correctness — notebook copy step, matrix, publish trigger
8. Tutorials and onboarding — no-HFSS path, Binder badge, Tutorial 6 execution
9. Ecosystem compatibility — quantum-metal import smoke test
10. Code hygiene — `print()` vs logger, bare `except`, stale TODOs

Produces a structured **Fixed / Needs attention / Clean / Skipped** report.

## Why this matters

The repo now has a documented, executable path for any future agent (or maintainer) to pick up the work without re-learning the pitfalls from scratch. The `/health-check` command is specifically designed so that periodic maintenance can be initiated with a single command and worked through systematically.

https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_