### PR TITLE
Add optional PyAEDT (gRPC) backend for HFSS field extraction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pyaedt-${{ hashFiles('pyproject.toml') }}-${{ env.PIPCACHEVERSION }}
-      - run: python -m pip install ".[pyaedt,test]"
+      # Pin the validated ansys-aedt-core for deterministic CI; the [pyaedt]
+      # extra itself allows the wider >=0.21,<1.0 range for users.
+      - run: python -m pip install ".[pyaedt,test]" "ansys-aedt-core==0.21.2"
       - name: Import smoke test (backend importable with PyAEDT installed)
         run: python -c "import pyEPR; from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis, compute_p_mj"
       - run: pytest tests/test_ansys_pyaedt.py -m "not hfss" -q

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,9 +61,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pyaedt-${{ hashFiles('pyproject.toml') }}-${{ env.PIPCACHEVERSION }}
-      # Pin the validated ansys-aedt-core for deterministic CI; the [pyaedt]
-      # extra itself allows the wider >=0.21,<1.0 range for users.
-      - run: python -m pip install ".[pyaedt,test]" "ansys-aedt-core==0.21.2"
+      # Install the [pyaedt] extra; its ansys-aedt-core>=0.21,<1.0 range resolves
+      # to whatever is available on PyPI.
+      - run: python -m pip install ".[pyaedt,test]"
       - name: Import smoke test (backend importable with PyAEDT installed)
         run: python -c "import pyEPR; from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis, compute_p_mj"
       - run: pytest tests/test_ansys_pyaedt.py -m "not hfss" -q

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,25 @@ jobs:
       - run: python -m pip install ".[test]"
       - run: pytest tests/ -m "not hfss" -q
 
+  test_pyaedt:
+    # Verify the optional [pyaedt] extra is installable and the PyAEDT backend's
+    # offline tests pass with PyAEDT present. The live (@pytest.mark.hfss) tests
+    # still require a real AEDT licence and remain excluded.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pyaedt-${{ hashFiles('pyproject.toml') }}-${{ env.PIPCACHEVERSION }}
+      - run: python -m pip install ".[pyaedt,test]"
+      - name: Import smoke test (backend importable with PyAEDT installed)
+        run: python -c "import pyEPR; from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis, compute_p_mj"
+      - run: pytest tests/test_ansys_pyaedt.py -m "not hfss" -q
+
   test_docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pyaedt-${{ hashFiles('pyproject.toml') }}-${{ env.PIPCACHEVERSION }}
+          restore-keys: |
+            pyaedt-
       # Install the [pyaedt] extra; its pyaedt>=0.9,<2.0 range resolves to
       # whatever is available on PyPI.
       - run: python -m pip install ".[pyaedt,test]"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,8 +61,8 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pyaedt-${{ hashFiles('pyproject.toml') }}-${{ env.PIPCACHEVERSION }}
-      # Install the [pyaedt] extra; its ansys-aedt-core>=0.21,<1.0 range resolves
-      # to whatever is available on PyPI.
+      # Install the [pyaedt] extra; its pyaedt>=0.9,<2.0 range resolves to
+      # whatever is available on PyPI.
       - run: python -m pip install ".[pyaedt,test]"
       - name: Import smoke test (backend importable with PyAEDT installed)
         run: python -c "import pyEPR; from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis, compute_p_mj"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 - **PyAEDT (gRPC) HFSS backend** (`pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`).
   Runs the same Energy-Participation-Ratio field extraction as
-  `DistributedAnalysis`, but through Ansys's official PyAEDT API
-  (`ansys-aedt-core`) entirely over gRPC — no COM / `pywin32`. PyAEDT can attach
+  `DistributedAnalysis`, but through Ansys's official PyAEDT library
+  (`pyaedt`) entirely over gRPC — no COM / `pywin32`. PyAEDT can attach
   to an already-running AEDT session that owns the project (via its `.aedt.lock`),
   avoiding stale-session and project-locked errors common with COM. The extracted
   participations feed pyEPR's own physics (`epr_to_zpf`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [Unreleased]
+
+### New features
+
+- **PyAEDT (gRPC) HFSS backend** (`pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`).
+  Runs the same Energy-Participation-Ratio field extraction as
+  `DistributedAnalysis`, but through Ansys's official PyAEDT API
+  (`ansys-aedt-core`) entirely over gRPC — no COM / `pywin32`. PyAEDT can attach
+  to an already-running AEDT session that owns the project (via its `.aedt.lock`),
+  avoiding stale-session and project-locked errors common with COM. The extracted
+  participations feed pyEPR's own physics (`epr_to_zpf`,
+  `epr_numerical_diagonalization`, `QuantumAnalysis`) unchanged; validated
+  digit-for-digit against the COM path (`p_mj = 0.9755` on a demo transmon).
+  PyAEDT is imported lazily behind the new `[pyaedt]` optional-dependency extra,
+  so `import pyEPR` never requires it. See `_tutorial_notebooks/` and the new
+  docs page.
+
 ## [0.9.5] — 2026-05-17
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ epra.analyze_all_variations(cos_trunc=8, fock_trunc=15)
 epra.plot_hamiltonian_results(swp_variable='Lj_alice')
 ```
 
+> **No COM?** `pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis` runs this same EPR
+> extraction through Ansys's official PyAEDT API entirely over gRPC instead of COM
+> (`pip install "pyEPR-quantum[pyaedt]"`). It feeds pyEPR's own diagonalizer and
+> matches the COM path digit-for-digit. See
+> [PyAEDT (gRPC) backend](https://pyepr-docs.readthedocs.io/en/latest/pyaedt_backend.html).
+
 ## Documentation
 
 **Full docs, API reference, and guides:** [pyepr-docs.readthedocs.io](https://pyepr-docs.readthedocs.io)

--- a/_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.ipynb
+++ b/_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "pyEPR has always driven HFSS through a hand-rolled **COM** layer (`pyEPR.ansys`), which is Windows-only and tied to a private scripting interface. This tutorial runs the *same* Energy-Participation-Ratio extraction through **PyAEDT** (`ansys-aedt-core`) — Ansys's official, maintained Python API — **entirely over gRPC, with no COM**, using `pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`.\n",
+    "pyEPR has always driven HFSS through a hand-rolled **COM** layer (`pyEPR.ansys`), which is Windows-only and tied to a private scripting interface. This tutorial runs the *same* Energy-Participation-Ratio extraction through **PyAEDT** (`pyaedt`) — Ansys's official, maintained Python API — **entirely over gRPC, with no COM**, using `pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`.\n",
     "\n",
     "The physics is unchanged. The extracted participations feed pyEPR's own `epr_to_zpf` and `epr_numerical_diagonalization` exactly as the COM path does, and the results match the COM path **digit-for-digit** (`p_mj = 0.9755` on this demo transmon).\n",
     "\n",
@@ -264,7 +264,7 @@
     "\n",
     "* **No COM / `pywin32`** — the transport is gRPC, the default since AEDT 2022 R2.\n",
     "* **Attaches to your running session** via the project's `.aedt.lock`, avoiding the stale-session and *project-locked* errors common with COM's Running-Object-Table lookup.\n",
-    "* **Maintenance moves to Ansys** — `ansys-aedt-core` is officially versioned and supported, rather than a private COM interface pyEPR has to track by hand across AEDT releases.\n",
+    "* **Maintenance moves to Ansys** — `pyaedt` is officially versioned and supported, rather than a private COM interface pyEPR has to track by hand across AEDT releases.\n",
     "\n",
     "For COM users nothing changes: `pyEPR.ansys` and `DistributedAnalysis` are untouched, and PyAEDT stays an optional extra."
    ]

--- a/_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.ipynb
+++ b/_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.ipynb
@@ -115,7 +115,7 @@
    "outputs": [],
    "source": [
     "pinfo = epr.ProjectInfo(\n",
-    "    project_path=r\"D:\\JYaker\\HFSS_Projects\",\n",
+    "    project_path=r\"C:\\path\\to\\your\\HFSS_Projects\",   # change to your project folder\n",
     "    project_name=\"EPR_Demo_Project\",\n",
     "    design_name=\"EPR_Sample_Demo\",\n",
     "    setup_name=\"EPR_Scan\",\n",

--- a/_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.ipynb
+++ b/_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ebf83cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "246c587d",
+   "metadata": {},
+   "source": [
+    "# Tutorial 7. EPR through PyAEDT (gRPC) — no COM\n",
+    "##### The same energy-participation extraction, over Ansys's official Python API\n",
+    "Author: Joey Yaker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eca7f4e6",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "pyEPR has always driven HFSS through a hand-rolled **COM** layer (`pyEPR.ansys`), which is Windows-only and tied to a private scripting interface. This tutorial runs the *same* Energy-Participation-Ratio extraction through **PyAEDT** (`ansys-aedt-core`) — Ansys's official, maintained Python API — **entirely over gRPC, with no COM**, using `pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`.\n",
+    "\n",
+    "The physics is unchanged. The extracted participations feed pyEPR's own `epr_to_zpf` and `epr_numerical_diagonalization` exactly as the COM path does, and the results match the COM path **digit-for-digit** (`p_mj = 0.9755` on this demo transmon).\n",
+    "\n",
+    "What actually differs is small and mechanical:\n",
+    "\n",
+    "| | COM (`pyEPR.ansys`) | PyAEDT (`pyEPR.ansys_pyaedt`) |\n",
+    "|---|---|---|\n",
+    "| transport | COM (.NET, Windows-only) | gRPC (default since AEDT 2022 R2) |\n",
+    "| connect | Running-Object-Table search | attach to the session that owns the `.aedt.lock` |\n",
+    "| field-calculator handle | `design.GetModule('FieldsReporter')` | `hfss.ofieldsreporter` |\n",
+    "| read a result back | `ClcEval` + `GetTopEntryValue` | `CalculatorWrite` to a `.fld` file |\n",
+    "\n",
+    "The field-calculator token stack (`EnterQty` / `ClcMaterial` / `EnterVol` / `EnterLine` / `Integrate`) and the eigenmode normalization (`Solutions.EditSources`) are **identical** between the two — they both run fine over gRPC. The single thing that does *not* survive gRPC is the stateful `ClcEval` read-back, which is why this backend writes results to a file with `CalculatorWrite` instead."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a98ccf43",
+   "metadata": {},
+   "source": [
+    "## <div style=\"background:#BBFABB;line-height:2em;\">Requirements<div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23a3dc2",
+   "metadata": {},
+   "source": [
+    "This backend needs PyAEDT, which pyEPR declares as an **optional** extra so that `import pyEPR` never requires it:\n",
+    "\n",
+    "```bash\n",
+    "pip install \"pyEPR-quantum[pyaedt]\"\n",
+    "```\n",
+    "\n",
+    "You also need a **solved** HFSS eigenmode design open in AEDT (the backend attaches to your running session). This tutorial uses a single-junction transmon solved for four eigenmodes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f91910e",
+   "metadata": {},
+   "source": [
+    "## <div style=\"background:#BBFABB;line-height:2em;\">Load pyEPR and the PyAEDT backend<div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8421d2ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pyEPR as epr\n",
+    "from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bba8270",
+   "metadata": {},
+   "source": [
+    "## <div style=\"background:#BBFABB;line-height:2em;\">Describe the project and its junctions<div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32fbc3b6",
+   "metadata": {},
+   "source": [
+    "A `ProjectInfo` describes *where* the design is and *what* the junctions are — exactly as in the COM workflow. The one difference: pass `do_connect=False`, because **PyAEDT** does the connecting, not pyEPR's COM layer.\n",
+    "\n",
+    "Each junction is declared with the same keys pyEPR uses:\n",
+    "\n",
+    "* `Lj_variable` — the HFSS design variable holding the junction inductance (e.g. `\"Lj_Transmon\"` = `\"12.9201nH\"`); read and parsed over gRPC. (You may instead give `Lj_henries` directly.)\n",
+    "* `line` — the polyline across the junction used for the line-voltage integral."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "29140141",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pinfo = epr.ProjectInfo(\n",
+    "    project_path=r\"D:\\JYaker\\HFSS_Projects\",\n",
+    "    project_name=\"EPR_Demo_Project\",\n",
+    "    design_name=\"EPR_Sample_Demo\",\n",
+    "    setup_name=\"EPR_Scan\",\n",
+    "    do_connect=False,            # PyAEDT does the connecting, not COM\n",
+    ")\n",
+    "\n",
+    "pinfo.junctions[\"j1\"] = {\n",
+    "    \"Lj_variable\": \"Lj_Transmon\",   # HFSS variable, e.g. '12.9201nH'\n",
+    "    \"line\": \"Junction_line\",        # polyline across the junction\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6f9d740",
+   "metadata": {},
+   "source": [
+    "## <div style=\"background:#BBFABB;line-height:2em;\">Extract the EPR over gRPC<div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e837779",
+   "metadata": {},
+   "source": [
+    "`PyaedtDistributedAnalysis` attaches to the running AEDT session (over gRPC, via the project's `.aedt.lock`), then for every eigenmode it:\n",
+    "\n",
+    "1. normalizes the fields to that mode with `Solutions.EditSources` (so the line voltage and the energy share one field scaling),\n",
+    "2. integrates the material-weighted electric energy $U_E \\propto \\mathrm{Re}\\!\\int \\mathbf{E}\\cdot\\varepsilon\\,\\mathbf{E}^* \\, dV$ over all objects, and\n",
+    "3. integrates the junction **line voltage** $V$ along each junction line,\n",
+    "\n",
+    "then forms the participation $p_{mj} = \\tfrac{1}{2}L_J (V/\\omega L_J)^2 \\,/\\, (U_E/2)$. All of it is pure gRPC; nothing here touches COM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9b777d9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mode 1:  f = 4.815509 GHz   p_mj = 0.9755   sign = -1\n",
+      "mode 2:  f = 5.060004 GHz   p_mj = 0.0061   sign = +1\n",
+      "mode 3:  f = 6.484727 GHz   p_mj = 0.0000   sign = -1\n",
+      "mode 4:  f = 6.489703 GHz   p_mj = 0.0000   sign = +1\n"
+     ]
+    }
+   ],
+   "source": [
+    "eprd = PyaedtDistributedAnalysis(pinfo, aedt_version=\"2026.1\")\n",
+    "eprd.do_EPR_analysis()\n",
+    "\n",
+    "for m, f in enumerate(eprd.freqs_GHz):\n",
+    "    print(f\"mode {m+1}:  f = {f:.6f} GHz   \"\n",
+    "          f\"p_mj = {eprd.PJ[m, 0]:.4f}   sign = {eprd.SJ[m, 0]:+d}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1443193a",
+   "metadata": {},
+   "source": [
+    "The results live on the analysis object as plain NumPy arrays — the same shapes pyEPR's diagonalizer expects (`M` modes × `J` junctions):\n",
+    "\n",
+    "* `eprd.freqs_GHz` — eigenfrequencies (GHz)\n",
+    "* `eprd.PJ` — participations $p_{mj}$\n",
+    "* `eprd.SJ` — signs $s_{mj}$\n",
+    "* `eprd.Ljs` — junction inductances (H), parsed from the HFSS variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c06da92f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "freqs_GHz : [4.815509 5.060004 6.484727 6.489703]\n",
+      "PJ        : [0.9755 0.0061 0.     0.    ]\n",
+      "SJ        : [-1  1 -1  1]\n",
+      "Ljs (nH)  : [12.9201]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"freqs_GHz :\", np.round(eprd.freqs_GHz, 6))\n",
+    "print(\"PJ        :\", np.round(eprd.PJ.ravel(), 4))\n",
+    "print(\"SJ        :\", eprd.SJ.ravel())\n",
+    "print(\"Ljs (nH)  :\", np.round(eprd.Ljs * 1e9, 4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a762c57d",
+   "metadata": {},
+   "source": [
+    "## <div style=\"background:#BBFABB;line-height:2em;\">Hand off to pyEPR's quantum analysis<div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ae22e37",
+   "metadata": {},
+   "source": [
+    "The extracted participations now go straight into pyEPR's own physics. `eprd.analyze()` is a thin wrapper over `pyEPR.calcs.back_box_numeric.epr_numerical_diagonalization` — the very function the COM `DistributedAnalysis` uses — so the quantum result is produced by unchanged pyEPR code.\n",
+    "\n",
+    "It returns the dressed mode frequencies and the cross-Kerr / anharmonicity matrix (MHz); the diagonal is each mode's anharmonicity $\\alpha$. Mode 1 is the qubit (it carries essentially all of the junction participation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1beb3ec6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qubit-mode anharmonicity alpha = 248.415 MHz\n"
+     ]
+    }
+   ],
+   "source": [
+    "f_ND, chi_ND = eprd.analyze(cos_trunc=8, fock_trunc=9)\n",
+    "alpha = np.abs(np.asarray(chi_ND))[0, 0]\n",
+    "print(f\"qubit-mode anharmonicity alpha = {alpha:.3f} MHz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1225cf48",
+   "metadata": {},
+   "source": [
+    "## Same physics, no COM\n",
+    "\n",
+    "The qubit-mode participation `p_mj = 0.9755` is **identical** to what pyEPR's COM path extracts from the same solved design — digit-for-digit — and everything downstream of it (here, a `248.415 MHz` anharmonicity from the four-mode diagonalization) follows from the same unchanged pyEPR physics. The only thing that changed is the road taken to HFSS: gRPC through Ansys's maintained PyAEDT API instead of COM.\n",
+    "\n",
+    "Practical upsides of the PyAEDT path:\n",
+    "\n",
+    "* **No COM / `pywin32`** — the transport is gRPC, the default since AEDT 2022 R2.\n",
+    "* **Attaches to your running session** via the project's `.aedt.lock`, avoiding the stale-session and *project-locked* errors common with COM's Running-Object-Table lookup.\n",
+    "* **Maintenance moves to Ansys** — `ansys-aedt-core` is officially versioned and supported, rather than a private COM interface pyEPR has to track by hand across AEDT releases.\n",
+    "\n",
+    "For COM users nothing changes: `pyEPR.ansys` and `DistributedAnalysis` are untouched, and PyAEDT stays an optional extra."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -108,6 +108,7 @@ Contents
    hfss_setup.rst
    examples_quick.rst
    without_hfss.rst
+   pyaedt_backend.rst
    tutorials.rst
    troubleshooting.rst
 

--- a/docs/source/pyaedt_backend.rst
+++ b/docs/source/pyaedt_backend.rst
@@ -1,0 +1,121 @@
+.. _pyaedt-backend:
+
+PyAEDT (gRPC) HFSS backend
+==========================
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+pyEPR has always driven Ansys HFSS through a hand-rolled **COM** layer
+(:mod:`pyEPR.ansys`), which is Windows-only and tied to a private scripting
+interface.  The :mod:`pyEPR.ansys_pyaedt` module performs the **same**
+Energy-Participation-Ratio field extraction through **PyAEDT**
+(``ansys-aedt-core``) — Ansys's official, maintained Python API — **entirely
+over gRPC, with no COM**.
+
+The physics is unchanged: the extracted participations feed pyEPR's own
+:meth:`~pyEPR.calcs.basic.CalcsBasic.epr_to_zpf` and
+:func:`~pyEPR.calcs.back_box_numeric.epr_numerical_diagonalization` exactly as
+the COM path does, and the results match the COM path digit-for-digit
+(:math:`p_{mj} = 0.9755` on the demo transmon).
+
+For COM users nothing changes — :mod:`pyEPR.ansys` and
+:class:`~pyEPR.DistributedAnalysis` are untouched, and PyAEDT remains an
+optional dependency.
+
+
+Why a gRPC backend
+------------------
+
+* **No COM / pywin32.**  The transport is gRPC, the default for AEDT since
+  2022 R2, instead of COM (.NET, Windows-only).
+* **Attaches to a running session.**  PyAEDT reads the project's
+  ``.aedt.lock`` and attaches to the AEDT instance that owns it, avoiding the
+  stale-session and *project-locked* errors common with COM's
+  Running-Object-Table lookup.
+* **Maintenance moves to Ansys.**  ``ansys-aedt-core`` is officially versioned
+  and supported, rather than a private COM interface pyEPR must track by hand
+  across AEDT releases.
+
+
+Installation
+------------
+
+PyAEDT is declared as an optional extra, so ``import pyEPR`` never requires it:
+
+.. code-block:: bash
+
+   pip install "pyEPR-quantum[pyaedt]"
+
+
+Usage
+-----
+
+Describe the project and its junctions with a :class:`~pyEPR.ProjectInfo`, just
+as in the COM workflow, but pass ``do_connect=False`` — PyAEDT does the
+connecting.  Each junction uses the same keys pyEPR already understands:
+``Lj_variable`` (or ``Lj_henries``) and ``line``.
+
+.. code-block:: python
+
+   import pyEPR as epr
+   from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis
+
+   pinfo = epr.ProjectInfo(
+       project_path=r"C:\HFSS_Projects",
+       project_name="EPR_Demo_Project",
+       design_name="EPR_Sample_Demo",
+       setup_name="EPR_Scan",
+       do_connect=False,            # PyAEDT does the connecting, not COM
+   )
+   pinfo.junctions["j1"] = {
+       "Lj_variable": "Lj_Transmon",   # HFSS variable, e.g. '12.9201nH'
+       "line": "Junction_line",        # polyline across the junction
+   }
+
+   eprd = PyaedtDistributedAnalysis(pinfo, aedt_version="2026.1")
+   eprd.do_EPR_analysis()              # pure gRPC field extraction
+
+   f_ND, chi_ND = eprd.analyze()       # pyEPR's own diagonalizer
+
+After :meth:`~pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis.do_EPR_analysis` the
+participations, signs, eigenfrequencies, and junction inductances are available
+as plain NumPy arrays on the object (``PJ``, ``SJ``, ``freqs_GHz``, ``Ljs``) —
+the same shapes pyEPR's diagonalizer expects.
+
+
+How it works over gRPC
+----------------------
+
+The field-calculator token stack (``EnterQty`` / ``ClcMaterial`` / ``EnterVol``
+/ ``EnterLine`` / ``Integrate``) and the eigenmode normalization
+(``Solutions.EditSources``) are identical to the COM path — they all run fine
+over gRPC.  Only two things differ:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * -
+     - COM (:mod:`pyEPR.ansys`)
+     - PyAEDT (:mod:`pyEPR.ansys_pyaedt`)
+   * - field-calculator handle
+     - ``design.GetModule('FieldsReporter')``
+     - ``hfss.ofieldsreporter``
+   * - read a result back
+     - ``ClcEval`` + ``GetTopEntryValue``
+     - ``CalculatorWrite`` to a ``.fld`` file
+
+The single operation that does **not** survive gRPC is the stateful
+``ClcEval`` / ``GetTopEntryValue`` read-back round-trip; writing the calculator
+result to a file with ``CalculatorWrite`` and reading it back is the equivalent
+that works over gRPC.
+
+
+See also
+--------
+
+* :ref:`Tutorial 7 <tutorials>` — a full worked example against a solved
+  transmon.
+* :mod:`pyEPR.ansys` — the original COM backend, unchanged.

--- a/docs/source/pyaedt_backend.rst
+++ b/docs/source/pyaedt_backend.rst
@@ -11,7 +11,7 @@ pyEPR has always driven Ansys HFSS through a hand-rolled **COM** layer
 (:mod:`pyEPR.ansys`), which is Windows-only and tied to a private scripting
 interface.  The :mod:`pyEPR.ansys_pyaedt` module performs the **same**
 Energy-Participation-Ratio field extraction through **PyAEDT**
-(``ansys-aedt-core``) — Ansys's official, maintained Python API — **entirely
+(``pyaedt``) — Ansys's official, maintained Python API — **entirely
 over gRPC, with no COM**.
 
 The physics is unchanged: the extracted participations feed pyEPR's own
@@ -34,7 +34,7 @@ Why a gRPC backend
   ``.aedt.lock`` and attaches to the AEDT instance that owns it, avoiding the
   stale-session and *project-locked* errors common with COM's
   Running-Object-Table lookup.
-* **Maintenance moves to Ansys.**  ``ansys-aedt-core`` is officially versioned
+* **Maintenance moves to Ansys.**  ``pyaedt`` is officially versioned
   and supported, rather than a private COM interface pyEPR must track by hand
   across AEDT releases.
 

--- a/docs/source/pyaedt_backend.rst
+++ b/docs/source/pyaedt_backend.rst
@@ -84,6 +84,12 @@ participations, signs, eigenfrequencies, and junction inductances are available
 as plain NumPy arrays on the object (``PJ``, ``SJ``, ``freqs_GHz``, ``Ljs``) —
 the same shapes pyEPR's diagonalizer expects.
 
+.. note::
+
+   This backend reads ``Cj_farads`` directly (a float, in farads) rather than
+   ``Cj_variable`` (an HFSS variable name used by the COM backend). Omit both to
+   treat the junction capacitance as zero.
+
 
 How it works over gRPC
 ----------------------
@@ -116,6 +122,5 @@ that works over gRPC.
 See also
 --------
 
-* :ref:`Tutorial 7 <tutorials>` — a full worked example against a solved
-  transmon.
+* `Tutorial 7 — EPR through PyAEDT (gRPC) <_tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.html>`__ — a full worked example against a solved transmon.
 * :mod:`pyEPR.ansys` — the original COM backend, unchanged.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -3,8 +3,8 @@
 Tutorial Notebooks
 ==================
 
-Six Jupyter notebook tutorials covering the full pyEPR workflow.
-Tutorials 1, 2, and 4 require a live Ansys HFSS session.
+Seven Jupyter notebook tutorials covering the full pyEPR workflow.
+Tutorials 1, 2, 4, and 7 require a live Ansys HFSS session.
 Tutorials 3, 5, and 6 run entirely with ``pip install pyEPR-quantum`` — no Ansys licence needed.
 
 .. grid:: 1
@@ -58,6 +58,14 @@ Tutorials 3, 5, and 6 run entirely with ``pip install pyEPR-quantum`` — no Ans
 
       Supply frequencies, junction inductances, and φ_zpf directly to get the full χ matrix — no EM solver needed. `Run on Binder ↗ <https://mybinder.org/v2/gh/zlatko-minev/pyEPR/master?filepath=_tutorial_notebooks%2FTutorial%206.%20EPR%20without%20HFSS%20%E2%80%94%20purely%20numerical%20workflow.ipynb>`__
 
+   .. grid-item-card:: Tutorial 7 — EPR through PyAEDT (gRPC), no COM
+      :link: _tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM.html
+      :link-type: url
+
+      :bdg-warning:`Ansys HFSS required`
+
+      Run the same EPR extraction through Ansys's official PyAEDT API entirely over gRPC — no COM. Attaches to a running AEDT session, feeds pyEPR's own diagonalizer, and matches the COM path digit-for-digit.
+
 .. toctree::
    :hidden:
    :maxdepth: 1
@@ -68,3 +76,4 @@ Tutorials 3, 5, and 6 run entirely with ``pip install pyEPR-quantum`` — no Ans
    _tutorial_notebooks/Tutorial 4. Parametric sweep options
    _tutorial_notebooks/Tutorial 5. Generic junction potential and fluxonium EPR
    _tutorial_notebooks/Tutorial 6. EPR without HFSS — purely numerical workflow
+   _tutorial_notebooks/Tutorial 7. EPR through PyAEDT (gRPC) — no COM

--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -201,6 +201,9 @@ from .core import (
     DistributedAnalysis,
     QuantumAnalysis,
 )
+# PyAEDT-based HFSS interface (modern alternative to the COM `ansys` module).
+# Imports PyAEDT/pywin32 lazily, so this never hard-requires them at import time.
+from .ansys_pyaedt import PyaedtDistributedAnalysis
 
 __all__ = [
     "logger",
@@ -212,6 +215,7 @@ __all__ = [
     "ProjectInfo",
     "DistributedAnalysis",
     "QuantumAnalysis",
+    "PyaedtDistributedAnalysis",
     "parse_units",
     "parse_units_user",
     "parse_entry",

--- a/pyEPR/ansys_pyaedt.py
+++ b/pyEPR/ansys_pyaedt.py
@@ -1,0 +1,453 @@
+"""
+PyAEDT-based HFSS interface for pyEPR — a modern alternative to :mod:`pyEPR.ansys`.
+
+pyEPR drives HFSS through the hand-rolled COM wrapper in :mod:`pyEPR.ansys`. This
+module performs the *same* Energy-Participation-Ratio field extraction through
+**PyAEDT** (``ansys.aedt.core``), Ansys's official, maintained Python API —
+**entirely over gRPC, with no COM at all**:
+
+* project / design / variation / frequency handling over PyAEDT's gRPC transport
+  (``Hfss(...)``), including *attach-to-a-running-session*;
+* eigenmode normalization via ``Solutions.EditSources`` (gRPC);
+* the junction **line** voltage and the material-weighted **volume** energy
+  integral ``Re∫ E·ε·E* dV`` over the gRPC field calculator
+  (``hfss.ofieldsreporter``), read back with ``CalculatorWrite`` to a file.
+
+The one subtlety that makes this work COM-free: results are read back with
+``CalculatorWrite`` (write to a ``.fld`` file), **not** ``ClcEval`` /
+``GetTopEntryValue`` — that stateful read-back round-trip is what does not survive
+gRPC. ``ClcMaterial`` (the permittivity multiply), ``EnterVol``, ``EnterLine`` and
+``Integrate`` all run fine over gRPC. Validated digit-for-digit against the COM
+path (``p_mj = 0.9755`` on the demo transmon).
+
+The extracted participations ``p_mj``, signs ``s_mj``, eigenfrequencies and
+``L_j`` feed pyEPR's own physics unchanged
+(:meth:`pyEPR.calcs.basic.CalcsBasic.epr_to_zpf`,
+:func:`pyEPR.calcs.back_box_numeric.epr_numerical_diagonalization`,
+:class:`pyEPR.QuantumAnalysis`).
+
+Junctions are declared exactly as in pyEPR — via ``ProjectInfo.junctions`` — using
+the keys ``Lj_variable`` (or ``Lj_henries``), ``line``, and an optional ``rect``
+or ``solid``.
+
+Requires
+--------
+* ``ansys-aedt-core`` (PyAEDT). No ``pywin32``/COM needed.
+
+Example
+-------
+>>> import pyEPR as epr
+>>> from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis
+>>> pinfo = epr.ProjectInfo(project_path=r"C:/proj", project_name="Demo",
+...                         design_name="Transmon", setup_name="Setup1",
+...                         do_connect=False)               # PyAEDT does the connecting
+>>> pinfo.junctions['j1'] = {'Lj_variable': 'Lj', 'line': 'jj_line', 'rect': 'jj_rect'}
+>>> eprd = PyaedtDistributedAnalysis(pinfo, aedt_version="2026.1")
+>>> eprd.do_EPR_analysis()
+>>> f_ND, chi_ND = eprd.analyze()        # uses pyEPR's epr_numerical_diagonalization
+>>> print(chi_ND.diagonal())             # anharmonicities (MHz)
+"""
+from __future__ import annotations
+
+import math
+import os
+import tempfile
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+__all__ = ["PyaedtDistributedAnalysis", "compute_p_mj"]
+
+
+# ---------------------------------------------------------------------------
+#  PyAEDT imported lazily so `import pyEPR` never hard-requires it.
+# ---------------------------------------------------------------------------
+def _require_pyaedt():
+    try:
+        from ansys.aedt.core import Hfss  # noqa: F401
+        from ansys.aedt.core.generic.general_methods import active_sessions  # noqa: F401
+        return Hfss, active_sessions
+    except Exception as exc:  # pragma: no cover - environment dependent
+        raise ImportError(
+            "PyAEDT is required for the ansys_pyaedt backend. "
+            "Install it with `pip install ansys-aedt-core`."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+#  Unit parsing  (e.g. "12.9201nH" -> 1.29201e-08)
+# ---------------------------------------------------------------------------
+_L_UNITS = [("nh", 1e-9), ("uh", 1e-6), ("mh", 1e-3), ("kh", 1e3), ("h", 1.0)]
+
+
+def _parse_henries(expr: str) -> float:
+    """Parse an inductance string with units into SI Henries."""
+    s = str(expr).strip().lower()
+    for unit, scale in _L_UNITS:
+        if s.endswith(unit):
+            return float(s[: -len(unit)]) * scale
+    return float(s)  # already unit-less / SI
+
+
+# ---------------------------------------------------------------------------
+#  p_mj — pyEPR's `line_voltage` recipe (pure arithmetic, no HFSS)
+# ---------------------------------------------------------------------------
+def compute_p_mj(
+    *,
+    V_peak: float,
+    freq_hz: float,
+    Lj_henries: float,
+    U_E_raw: float,
+    Cj_farads: float = 0.0,
+    sum_Ucap_other: float = 0.0,
+) -> Tuple[float, int]:
+    """Junction participation ``p_mj`` and sign from a line voltage.
+
+    Mirrors :meth:`pyEPR.DistributedAnalysis.calc_p_junction` (``line_voltage``)::
+
+        ω      = 2π f
+        I_peak = V_peak / (ω · L_J)
+        U_J_ind = ½ · L_J · I_peak²
+        U_J_cap = ½ · C_J · V_peak²
+        U_norm  = U_E_raw/2 + Σ_j U_J_cap
+        p_mj    = U_J_ind / U_norm,   s_mj = +1 if V_peak > 0 else -1
+
+    ``U_E_raw`` is the raw electric integral ``Re∫E·εE* dV`` for the whole mode
+    (= 4·U_E), exactly what pyEPR's ``calc_energy_electric`` returns and halves.
+
+    Returns ``(p_mj, sign)``.
+    """
+    if Lj_henries <= 0 or freq_hz <= 0:
+        raise ValueError("Lj_henries and freq_hz must be > 0")
+    omega = 2.0 * math.pi * freq_hz
+    I_peak = V_peak / (omega * Lj_henries)
+    U_J_ind = 0.5 * Lj_henries * I_peak ** 2
+    U_J_cap = 0.5 * Cj_farads * V_peak ** 2
+    U_norm = (U_E_raw / 2.0) + U_J_cap + sum_Ucap_other
+    if U_norm <= 0:
+        raise ValueError(
+            f"non-positive U_norm ({U_norm}); the mode has no electric energy "
+            f"(U_E_raw={U_E_raw}). Is the mode solved and selected?"
+        )
+    return U_J_ind / U_norm, (1 if V_peak > 0 else -1)
+
+
+# ---------------------------------------------------------------------------
+#  gRPC field calculator (no COM)
+# ---------------------------------------------------------------------------
+class _GrpcFieldCalc:
+    """Field calculator + eigenmode selection over PyAEDT's **gRPC** handle.
+
+    No COM. Two design points make this work where the naive approach fails:
+
+    1. **Normalize the eigenmode with ``EditSources``** (the ``Solutions`` module
+       call, which *does* run over gRPC) before reading any field. This gives the
+       line voltage and the energy a single, self-consistent field scaling — the
+       coupling that otherwise makes ``p_mj`` come out wrong.
+    2. **Read results back with ``CalculatorWrite``** (write to a ``.fld`` file),
+       NOT ``ClcEval``/``GetTopEntryValue`` — that stateful read-back is the one
+       thing that doesn't survive gRPC. ``ClcMaterial`` / ``EnterVol`` /
+       ``EnterLine`` / ``Integrate`` themselves are all fine over gRPC.
+    """
+
+    def __init__(self, hfss, setup_solution: str):
+        self._ofr = hfss.ofieldsreporter
+        self._sol = hfss.odesign.GetModule("Solutions")
+        self._setup = setup_solution
+        self._wdir = getattr(hfss, "working_directory", None) or tempfile.gettempdir()
+
+    def set_mode(self, mode_index_0based: int, phase: float = 0.0) -> None:
+        """Normalize fields to one eigenmode via EditSources (over gRPC)."""
+        n = mode_index_0based + 1            # HFSS is 1-based
+        n_modes = max(10, n)
+        mags = ["1" if i + 1 == n else "0" for i in range(n_modes)]
+        phs = [str(phase) if i + 1 == n else "0" for i in range(n_modes)]
+        self._sol.EditSources(
+            [
+                ["FieldType:=", "EigenPeakElectricField"],
+                ["Name:=", "Modes", "Magnitudes:=", mags, "Phases:=", phs],
+            ]
+        )
+
+    def _evaluate(self, build) -> float:
+        """Build a calculator stack and read it back over gRPC via CalculatorWrite."""
+        ofr = self._ofr
+        ofr.CalcStack("clear")
+        build(ofr)
+        path = os.path.join(self._wdir, "epr_calc.fld")
+        if os.path.isfile(path):
+            os.remove(path)
+        ofr.CalculatorWrite(path, ["Solution:=", self._setup], ["Phase:=", "0deg"])
+        with open(path) as fh:
+            val = float(fh.readlines()[-1].strip())
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        ofr.CalcStack("clear")
+        return val
+
+    def energy_electric(self, obj: str = "AllObjects") -> float:
+        """Raw electric integral ``Re∫ E·ε·E* dV`` (= 4·U_E) over ``obj``, over gRPC."""
+        def build(o):
+            o.EnterQty("E")
+            o.ClcMaterial("Permittivity (epsi)", "mult")   # material multiply over gRPC
+            o.EnterQty("E")
+            o.CalcOp("Conj")
+            o.CalcOp("Dot")
+            o.CalcOp("Real")
+            o.EnterVol(obj)
+            o.CalcOp("Integrate")
+        return self._evaluate(build)
+
+    def line_voltage(self, line: str) -> float:
+        """Signed peak line voltage ``sign(Re)·√(Re²+Im²)`` along ``line``, over gRPC."""
+        def part(p):
+            def build(o):
+                o.EnterQty("E")
+                o.CalcOp(p)                 # "Real" or "Imag"
+                o.EnterLine(line)
+                o.CalcOp("Tangent")
+                o.CalcOp("Dot")
+                o.EnterLine(line)
+                o.CalcOp("Integrate")
+            return build
+        re = self._evaluate(part("Real"))
+        im = self._evaluate(part("Imag"))
+        mag = math.sqrt(re * re + im * im)
+        return mag if re >= 0 else -mag
+
+
+# ---------------------------------------------------------------------------
+#  Session targeting (multi-session safe)
+# ---------------------------------------------------------------------------
+def _owning_session_from_lock(project_path: str, grpc: Dict[int, int]):
+    """``(pid, port)`` of the running gRPC session that holds this project's lock.
+
+    AEDT writes the owning ``DesktopProcessID`` into ``<project>.aedt.lock``;
+    attaching there means we use the session the user already has the project open
+    in, instead of an arbitrary (possibly wrong-version) instance.
+    """
+    lock = str(project_path) + ".lock"
+    if not os.path.isfile(lock):
+        return None
+    pid = None
+    try:
+        for ln in open(lock, errors="ignore"):
+            if ln.strip().startswith("DesktopProcessID="):
+                pid = int(ln.strip().split("=", 1)[1])
+                break
+    except (OSError, ValueError):
+        return None
+    return (pid, grpc[pid]) if pid in grpc else None
+
+
+# ---------------------------------------------------------------------------
+#  Main analysis object
+# ---------------------------------------------------------------------------
+class PyaedtDistributedAnalysis:
+    """EPR field extraction through PyAEDT (pure gRPC) — the PyAEDT analogue of
+    :class:`pyEPR.DistributedAnalysis`.
+
+    After :meth:`do_EPR_analysis` the results live on the object as plain NumPy
+    arrays: ``freqs_GHz`` (M,), ``Ljs`` (J,), ``PJ`` (M by J ``p_mj``) and
+    ``SJ`` (M by J signs) — the inputs pyEPR's diagonalizer needs.
+
+    Parameters
+    ----------
+    project_info : pyEPR.ProjectInfo
+        Construct it with ``do_connect=False`` — PyAEDT does the connecting.
+        Junctions are read from ``project_info.junctions`` using the keys
+        ``Lj_variable`` (or ``Lj_henries``), ``line`` and, optionally,
+        ``rect`` / ``solid``.
+    aedt_version : str
+        AEDT version string, e.g. ``"2026.1"``.
+    non_graphical : bool
+        Forwarded to PyAEDT only when no running session is found.
+    new_desktop : bool
+        Forwarded to PyAEDT only when no running session is found; when a
+        session is already running this object attaches to it instead.
+    """
+
+    def __init__(
+        self,
+        project_info,
+        aedt_version: str = "2026.1",
+        non_graphical: bool = False,
+        new_desktop: bool = False,
+    ):
+        self.pinfo = project_info
+        self.aedt_version = aedt_version
+        self.non_graphical = non_graphical
+        self.new_desktop = new_desktop
+
+        self._hfss = None
+        self.junction_names: List[str] = list(getattr(project_info, "junctions", {}) or {})
+
+        # Results (populated by do_EPR_analysis)
+        self.freqs_GHz: Optional[np.ndarray] = None
+        self.Ljs: Optional[np.ndarray] = None
+        self.PJ: Optional[np.ndarray] = None
+        self.SJ: Optional[np.ndarray] = None
+        self.results: Dict = {}
+
+    # ---- connection --------------------------------------------------------
+    @property
+    def _project_path(self) -> str:
+        """Full ``.aedt`` path from the ProjectInfo (``project_path`` + name)."""
+        p = self.pinfo.project_path
+        name = self.pinfo.project_name
+        if p and name and not str(p).lower().endswith(".aedt"):
+            return os.path.join(str(p), f"{name}.aedt")
+        return str(p)
+
+    def connect(self):
+        """Attach to (or open) the project through PyAEDT — pure gRPC."""
+        Hfss, active_sessions = _require_pyaedt()
+        project_path = self._project_path
+
+        sessions = {}
+        try:
+            sessions = active_sessions(
+                version=self.aedt_version, student_version=False,
+                non_graphical=False) or {}
+        except Exception:
+            sessions = {}
+        grpc = {pid: port for pid, port in sessions.items() if port and port > 0}
+
+        if grpc:
+            owner = _owning_session_from_lock(project_path, grpc)
+            pid, port = owner if owner else (next(iter(grpc)), grpc[next(iter(grpc))])
+            self._hfss = Hfss(
+                project=project_path, design=self.pinfo.design_name,
+                version=self.aedt_version, port=port, aedt_process_id=pid,
+                new_desktop=False, non_graphical=False)
+        else:
+            self._hfss = Hfss(
+                project=project_path, design=self.pinfo.design_name,
+                version=self.aedt_version, non_graphical=self.non_graphical,
+                new_desktop=self.new_desktop)
+        return self
+
+    def disconnect(self):
+        """Release the PyAEDT handle without closing a project we didn't open."""
+        if self._hfss is not None:
+            try:
+                self._hfss.release_desktop(close_projects=False,
+                                           close_desktop=self.new_desktop)
+            except Exception:
+                pass
+            self._hfss = None
+
+    def __enter__(self):
+        return self.connect()
+
+    def __exit__(self, *exc):
+        self.disconnect()
+
+    # ---- extraction --------------------------------------------------------
+    def _resolve_Lj(self, jdict) -> float:
+        """Junction inductance in Henries from a junction dict.
+
+        Uses ``Lj_henries`` if given; otherwise reads the HFSS design variable
+        named by ``Lj_variable`` (e.g. ``"12.9201nH"``) over gRPC and parses it.
+        """
+        if jdict.get("Lj_henries") is not None:
+            return float(jdict["Lj_henries"])
+        var = jdict.get("Lj_variable")
+        if not var:
+            raise ValueError("junction needs 'Lj_variable' or 'Lj_henries'")
+        return _parse_henries(self._hfss.odesign.GetVariableValue(var))
+
+    def _eigenfrequencies(self, setup_solution: str, variation: str = "") -> np.ndarray:
+        """Eigenmode frequencies (GHz) via ExportEigenmodes on the gRPC Solutions module."""
+        fd, path = tempfile.mkstemp(suffix=".txt", prefix="pyaedt_eig_")
+        os.close(fd)
+        try:
+            self._hfss.odesign.GetModule("Solutions").ExportEigenmodes(
+                setup_solution, variation, path)
+            data = np.genfromtxt(path, dtype="str")
+            if data.ndim == 1:
+                data = np.array([data])
+            return np.array([float(row[1]) for row in data])   # column 1 = GHz
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+    def do_EPR_analysis(self, variation: str = "", modes: Optional[List[int]] = None):
+        """Extract ``p_mj``, signs, frequencies and ``L_j`` for every mode — pure gRPC.
+
+        Populates ``self.freqs_GHz``, ``self.Ljs``, ``self.PJ`` (M×J), ``self.SJ``
+        (M×J). Returns ``self``.
+        """
+        if self._hfss is None:
+            self.connect()
+        setup_solution = f"{self.pinfo.setup_name} : LastAdaptive"
+        fc = _GrpcFieldCalc(self._hfss, setup_solution)
+
+        freqs = self._eigenfrequencies(setup_solution, variation)
+        if modes is None:
+            modes = list(range(len(freqs)))
+        freqs = freqs[modes]
+        M = len(modes)
+
+        jnames = self.junction_names
+        J = len(jnames)
+        jdicts = [self.pinfo.junctions[n] for n in jnames]
+        Ljs = np.array([self._resolve_Lj(jd) for jd in jdicts]) if J else np.array([])
+
+        PJ = np.zeros((M, J))
+        SJ = np.ones((M, J), dtype=int)
+
+        for mi, mode in enumerate(modes):
+            fc.set_mode(mode)                          # EditSources normalization (gRPC)
+            U_E_raw = fc.energy_electric("AllObjects")
+            Ucaps, Vs = [], []
+            for jd in jdicts:
+                V = fc.line_voltage(jd["line"])
+                Vs.append(V)
+                Ucaps.append(0.5 * float(jd.get("Cj_farads", 0.0) or 0.0) * V * V)
+            for ji, jd in enumerate(jdicts):
+                p, s = compute_p_mj(
+                    V_peak=Vs[ji], freq_hz=float(freqs[mi]) * 1e9,
+                    Lj_henries=float(Ljs[ji]), U_E_raw=U_E_raw,
+                    Cj_farads=float(jd.get("Cj_farads", 0.0) or 0.0),
+                    sum_Ucap_other=sum(Ucaps) - Ucaps[ji],
+                )
+                PJ[mi, ji] = p
+                SJ[mi, ji] = s
+
+        self.freqs_GHz, self.Ljs, self.PJ, self.SJ = freqs, Ljs, PJ, SJ
+        self.results = {
+            "freqs_hfss_GHz": freqs, "Ljs": Ljs, "Pm": PJ, "Sm": SJ,
+            "junctions": jnames, "modes": modes,
+        }
+        return self
+
+    # ---- hand off to pyEPR's physics --------------------------------------
+    def epr_zpf(self) -> np.ndarray:
+        """Reduced zero-point flux ``ϕ_zpf`` (M×J) via pyEPR's ``epr_to_zpf``."""
+        from .calcs.basic import CalcsBasic
+
+        if self.PJ is None:
+            raise RuntimeError("call do_EPR_analysis() first")
+        H = 6.62607015e-34
+        PHI0_RED = 3.29105976e-16
+        EJ_GHz = np.array([(PHI0_RED ** 2 / (Lj * H)) / 1e9 for Lj in self.Ljs])
+        return CalcsBasic.epr_to_zpf(
+            self.PJ, self.SJ, np.diag(self.freqs_GHz), np.diag(EJ_GHz))
+
+    def analyze(self, cos_trunc: int = 8, fock_trunc: int = 7):
+        """Numerically diagonalize via pyEPR's ``epr_numerical_diagonalization``.
+
+        Returns ``(f_ND, chi_ND)`` — dressed frequencies (GHz) and the cross-Kerr /
+        anharmonicity matrix (MHz, diagonal = anharmonicity).
+        """
+        from .calcs.back_box_numeric import epr_numerical_diagonalization
+
+        phi = self.epr_zpf()
+        return epr_numerical_diagonalization(
+            self.freqs_GHz, np.asarray(self.Ljs), phi,
+            cos_trunc=cos_trunc, fock_trunc=fock_trunc)

--- a/pyEPR/ansys_pyaedt.py
+++ b/pyEPR/ansys_pyaedt.py
@@ -64,8 +64,8 @@ __all__ = ["PyaedtDistributedAnalysis", "compute_p_mj"]
 # ---------------------------------------------------------------------------
 def _require_pyaedt():
     try:
-        from ansys.aedt.core import Hfss  # noqa: F401
-        from ansys.aedt.core.generic.general_methods import active_sessions  # noqa: F401
+        from ansys.aedt.core import Hfss  # noqa: F401  # pylint: disable=import-error
+        from ansys.aedt.core.generic.general_methods import active_sessions  # noqa: F401  # pylint: disable=import-error
         return Hfss, active_sessions
     except Exception as exc:  # pragma: no cover - environment dependent
         raise ImportError(

--- a/pyEPR/ansys_pyaedt.py
+++ b/pyEPR/ansys_pyaedt.py
@@ -234,10 +234,11 @@ def _owning_session_from_lock(project_path: str, grpc: Dict[int, int]):
         return None
     pid = None
     try:
-        for ln in open(lock, errors="ignore"):
-            if ln.strip().startswith("DesktopProcessID="):
-                pid = int(ln.strip().split("=", 1)[1])
-                break
+        with open(lock, errors="ignore") as fh:
+            for ln in fh:
+                if ln.strip().startswith("DesktopProcessID="):
+                    pid = int(ln.strip().split("=", 1)[1])
+                    break
     except (OSError, ValueError):
         return None
     return (pid, grpc[pid]) if pid in grpc else None

--- a/pyEPR/ansys_pyaedt.py
+++ b/pyEPR/ansys_pyaedt.py
@@ -32,7 +32,8 @@ or ``solid``.
 
 Requires
 --------
-* ``ansys-aedt-core`` (PyAEDT). No ``pywin32``/COM needed.
+* ``pyaedt`` (PyAEDT; provides the ``ansys.aedt.core`` namespace). No
+  ``pywin32``/COM needed.
 
 Example
 -------
@@ -70,7 +71,7 @@ def _require_pyaedt():
     except Exception as exc:  # pragma: no cover - environment dependent
         raise ImportError(
             "PyAEDT is required for the ansys_pyaedt backend. "
-            "Install it with `pip install ansys-aedt-core`."
+            "Install it with `pip install pyaedt`."
         ) from exc
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,10 @@ test = [
 ]
 # Modern HFSS interface (pyEPR.ansys_pyaedt) — talk to HFSS through Ansys's
 # official PyAEDT API instead of the COM `ansys` module. Windows-only.
+# Validated against ansys-aedt-core 0.21.2; pinned below the next major as a
+# safety bound (ansys-aedt-core is pre-1.0). Widen once newer releases are tested.
 pyaedt = [
-    "ansys-aedt-core>=0.21",
+    "ansys-aedt-core>=0.21,<1.0",
     "pywin32; platform_system == 'Windows'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,13 +68,13 @@ test = [
     "pytest-cov",
 ]
 # Modern HFSS interface (pyEPR.ansys_pyaedt) — talk to HFSS through Ansys's
-# official PyAEDT API (ansys-aedt-core) over gRPC instead of COM.
+# official PyAEDT library over gRPC instead of COM. The PyPI package is `pyaedt`;
+# it provides the `ansys.aedt.core` import namespace (since pyaedt 0.9).
 # Unlike the COM backend, gRPC works on Linux and macOS.
 # pywin32 is only needed on Windows as an internal PyAEDT dependency.
-# Validated against ansys-aedt-core 0.21.2; pinned below the next major as a
-# safety bound (ansys-aedt-core is pre-1.0). Widen once newer releases are tested.
+# Validated against pyaedt 0.21.2.
 pyaedt = [
-    "ansys-aedt-core>=0.21,<1.0",
+    "pyaedt>=0.9,<2.0",
     "pywin32; platform_system == 'Windows'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,9 @@ test = [
     "pytest-cov",
 ]
 # Modern HFSS interface (pyEPR.ansys_pyaedt) — talk to HFSS through Ansys's
-# official PyAEDT API instead of the COM `ansys` module. Windows-only.
+# official PyAEDT API (ansys-aedt-core) over gRPC instead of COM.
+# Unlike the COM backend, gRPC works on Linux and macOS.
+# pywin32 is only needed on Windows as an internal PyAEDT dependency.
 # Validated against ansys-aedt-core 0.21.2; pinned below the next major as a
 # safety bound (ansys-aedt-core is pre-1.0). Widen once newer releases are tested.
 pyaedt = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ test = [
     "pytest>=7.0",
     "pytest-cov",
 ]
+# Modern HFSS interface (pyEPR.ansys_pyaedt) — talk to HFSS through Ansys's
+# official PyAEDT API instead of the COM `ansys` module. Windows-only.
+pyaedt = [
+    "ansys-aedt-core>=0.21",
+    "pywin32; platform_system == 'Windows'",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ test = [
     "pytest-cov",
 ]
 # Modern HFSS interface (pyEPR.ansys_pyaedt) — talk to HFSS through Ansys's
-# official PyAEDT library over gRPC instead of COM. The PyPI package is `pyaedt`;
-# it provides the `ansys.aedt.core` import namespace (since pyaedt 0.9).
+# official PyAEDT library (pyaedt) over gRPC instead of COM.
+# The `pyaedt` package (PyPI) provides the `ansys.aedt.core` import namespace.
 # Unlike the COM backend, gRPC works on Linux and macOS.
 # pywin32 is only needed on Windows as an internal PyAEDT dependency.
-# Validated against pyaedt 0.21.2.
+# Validated against pyaedt 1.1.0 (current PyPI release).
 pyaedt = [
     "pyaedt>=0.9,<2.0",
     "pywin32; platform_system == 'Windows'",

--- a/tests/test_ansys_pyaedt.py
+++ b/tests/test_ansys_pyaedt.py
@@ -1,0 +1,180 @@
+"""
+Tests for pyEPR.ansys_pyaedt — the PyAEDT (gRPC) HFSS backend.
+
+The backend talks to HFSS through Ansys's PyAEDT API over gRPC, but its
+*physics* (the junction participation formula), its unit parsing, and its
+session-targeting logic are pure Python and are tested here without Ansys,
+COM, PyAEDT, or Windows.
+
+Only the single ``@pytest.mark.hfss`` test needs a live AEDT session; it is
+skipped in CI and is also skipped locally unless the env var
+``PYEPR_PYAEDT_TEST_PROJECT`` points at a solved demo ``.aedt`` project.
+
+Designed to run on Linux/macOS/Windows with no optional dependencies.
+"""
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from pyEPR.ansys_pyaedt import (
+    PyaedtDistributedAnalysis,
+    compute_p_mj,
+    _parse_henries,
+    _owning_session_from_lock,
+    _require_pyaedt,
+)
+
+
+# ── compute_p_mj — the junction participation formula ───────────────────────
+
+# Golden values from the demo transmon, validated digit-for-digit against the
+# COM path (qubit eigenmode 4.815509 GHz, Lj 12.9201 nH).
+GOLDEN_V = -2.200983e-05
+GOLDEN_FREQ_HZ = 4.815509e9
+GOLDEN_LJ_H = 12.9201e-9
+GOLDEN_UE_RAW = 4.198685e-23
+
+
+def test_compute_p_mj_matches_golden_transmon():
+    p, sign = compute_p_mj(
+        V_peak=GOLDEN_V,
+        freq_hz=GOLDEN_FREQ_HZ,
+        Lj_henries=GOLDEN_LJ_H,
+        U_E_raw=GOLDEN_UE_RAW,
+    )
+    assert p == pytest.approx(0.9755, abs=2e-3)
+    assert sign == -1
+
+
+def test_compute_p_mj_sign_follows_voltage():
+    common = dict(freq_hz=GOLDEN_FREQ_HZ, Lj_henries=GOLDEN_LJ_H, U_E_raw=GOLDEN_UE_RAW)
+    p_pos, s_pos = compute_p_mj(V_peak=abs(GOLDEN_V), **common)
+    p_neg, s_neg = compute_p_mj(V_peak=-abs(GOLDEN_V), **common)
+    assert s_pos == +1 and s_neg == -1
+    # participation is sign-independent (V enters squared)
+    assert p_pos == pytest.approx(p_neg)
+
+
+def test_compute_p_mj_capacitance_lowers_participation():
+    base, _ = compute_p_mj(
+        V_peak=GOLDEN_V, freq_hz=GOLDEN_FREQ_HZ,
+        Lj_henries=GOLDEN_LJ_H, U_E_raw=GOLDEN_UE_RAW,
+    )
+    with_cj, _ = compute_p_mj(
+        V_peak=GOLDEN_V, freq_hz=GOLDEN_FREQ_HZ,
+        Lj_henries=GOLDEN_LJ_H, U_E_raw=GOLDEN_UE_RAW,
+        Cj_farads=1e-15,
+    )
+    # adding junction capacitance grows the normalization → smaller p_mj
+    assert with_cj < base
+
+
+def test_compute_p_mj_rejects_bad_inputs():
+    with pytest.raises(ValueError):
+        compute_p_mj(V_peak=1.0, freq_hz=0.0, Lj_henries=GOLDEN_LJ_H, U_E_raw=1e-23)
+    with pytest.raises(ValueError):
+        compute_p_mj(V_peak=1.0, freq_hz=GOLDEN_FREQ_HZ, Lj_henries=0.0, U_E_raw=1e-23)
+    with pytest.raises(ValueError):
+        # non-positive electric energy → undefined normalization
+        compute_p_mj(V_peak=1.0, freq_hz=GOLDEN_FREQ_HZ, Lj_henries=GOLDEN_LJ_H, U_E_raw=0.0)
+
+
+# ── _parse_henries — inductance string → SI Henries ─────────────────────────
+
+@pytest.mark.parametrize("expr,expected", [
+    ("12.9201nH", 12.9201e-9),
+    ("5uH", 5e-6),
+    ("2mH", 2e-3),
+    ("1.5H", 1.5),
+    ("12.9201NH", 12.9201e-9),   # case-insensitive
+    ("  3nH ", 3e-9),            # surrounding whitespace
+    ("4e-9", 4e-9),             # unit-less / already SI
+    ("4.2", 4.2),
+])
+def test_parse_henries(expr, expected):
+    assert _parse_henries(expr) == pytest.approx(expected)
+
+
+# ── _owning_session_from_lock — .aedt.lock targeting ────────────────────────
+
+def test_owning_session_reads_pid_from_lock(tmp_path):
+    project = tmp_path / "Demo.aedt"
+    lock = tmp_path / "Demo.aedt.lock"
+    lock.write_text("SomeHeader=1\nDesktopProcessID=4242\nOther=x\n")
+    grpc = {4242: 50051, 9999: 50060}
+    assert _owning_session_from_lock(str(project), grpc) == (4242, 50051)
+
+
+def test_owning_session_none_when_pid_not_running(tmp_path):
+    project = tmp_path / "Demo.aedt"
+    (tmp_path / "Demo.aedt.lock").write_text("DesktopProcessID=4242\n")
+    assert _owning_session_from_lock(str(project), {9999: 50051}) is None
+
+
+def test_owning_session_none_when_no_lock(tmp_path):
+    project = tmp_path / "Demo.aedt"
+    assert _owning_session_from_lock(str(project), {4242: 50051}) is None
+
+
+# ── lazy PyAEDT import — backend must import without ansys-aedt-core ─────────
+
+def test_backend_imports_and_constructs_without_pyaedt():
+    """Importing the backend and constructing the object must not need PyAEDT."""
+    pinfo = SimpleNamespace(
+        junctions={}, project_path=None, project_name=None,
+        design_name=None, setup_name=None,
+    )
+    obj = PyaedtDistributedAnalysis(pinfo, aedt_version="2026.1")
+    assert obj.junction_names == []
+    assert obj.PJ is None  # not analyzed yet
+
+
+def test_require_pyaedt_raises_clear_error_when_missing(monkeypatch):
+    """When ansys-aedt-core is absent, the error must name PyAEDT and how to fix it."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("ansys.aedt"):
+            raise ImportError("simulated missing PyAEDT")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="PyAEDT is required"):
+        _require_pyaedt()
+
+
+# ── live extraction (needs AEDT + the solved demo project) ──────────────────
+
+@pytest.mark.hfss
+def test_live_pmj_matches_golden():
+    """End-to-end p_mj from a live AEDT session equals the golden 0.9755.
+
+    Skipped unless ``PYEPR_PYAEDT_TEST_PROJECT`` points at the solved demo
+    ``.aedt``; requires AEDT open with that project. Mirrors the demo notebook.
+    """
+    project = os.environ.get("PYEPR_PYAEDT_TEST_PROJECT")
+    if not project:
+        pytest.skip("set PYEPR_PYAEDT_TEST_PROJECT to the solved demo .aedt to run")
+
+    import pyEPR as epr
+
+    pinfo = epr.ProjectInfo(
+        project_path=os.path.dirname(project),
+        project_name=os.path.splitext(os.path.basename(project))[0],
+        design_name="EPR_Sample_Demo",
+        setup_name="EPR_Scan",
+        do_connect=False,
+    )
+    pinfo.junctions["j1"] = {"Lj_variable": "Lj_Transmon", "line": "Junction_line"}
+
+    eprd = PyaedtDistributedAnalysis(pinfo, aedt_version="2026.1")
+    try:
+        eprd.do_EPR_analysis()
+    finally:
+        eprd.disconnect()
+
+    # qubit mode is the one with participation near unity
+    assert eprd.PJ.max() == pytest.approx(0.9755, abs=2e-3)

--- a/tests/test_ansys_pyaedt.py
+++ b/tests/test_ansys_pyaedt.py
@@ -117,7 +117,7 @@ def test_owning_session_none_when_no_lock(tmp_path):
     assert _owning_session_from_lock(str(project), {4242: 50051}) is None
 
 
-# ── lazy PyAEDT import — backend must import without ansys-aedt-core ─────────
+# ── lazy PyAEDT import — backend must import without pyaedt ──────────────────
 
 def test_backend_imports_and_constructs_without_pyaedt():
     """Importing the backend and constructing the object must not need PyAEDT."""
@@ -131,7 +131,7 @@ def test_backend_imports_and_constructs_without_pyaedt():
 
 
 def test_require_pyaedt_raises_clear_error_when_missing(monkeypatch):
-    """When ansys-aedt-core is absent, the error must name PyAEDT and how to fix it."""
+    """When pyaedt is absent, the error must name PyAEDT and how to fix it."""
     import builtins
 
     real_import = builtins.__import__


### PR DESCRIPTION
Closes #206 .

## Summary

This PR adds an **optional** way to run pyEPR's Energy-Participation-Ratio field
extraction through **PyAEDT** (`ansys-aedt-core`) — Ansys's official, maintained
Python API — **entirely over gRPC, with no COM / `pywin32`**.

It is fully **additive**: `pyEPR.ansys`, `DistributedAnalysis`, and every existing
code path are untouched. The new backend lives in a separate module
(`pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`) and PyAEDT is imported lazily
behind a new `[pyaedt]` optional-dependency extra, so `import pyEPR` never
requires it.

```python
import pyEPR as epr
from pyEPR.ansys_pyaedt import PyaedtDistributedAnalysis

pinfo = epr.ProjectInfo(project_path=..., project_name=..., design_name=...,
                        setup_name=..., do_connect=False)
pinfo.junctions["j1"] = {"Lj_variable": "Lj", "line": "jj_line"}

eprd = PyaedtDistributedAnalysis(pinfo, aedt_version="2026.1")
eprd.do_EPR_analysis()          # pure gRPC field extraction
f_ND, chi_ND = eprd.analyze()   # feeds pyEPR's own diagonalizer
```

## Why

- COM is Windows-only, unmaintained on Ansys's side, and brittle across AEDT
  versions.
- gRPC is PyAEDT's default transport since AEDT 2022 R2, and PyAEDT attaches to the
  AEDT instance that owns the project (via its `.aedt.lock`), avoiding the
  stale-session and *project-locked* errors common with COM.
- Maintenance of the transport layer moves onto Ansys's officially versioned API.

## How it works (the one technical point)

The extracted participations feed pyEPR's own physics unchanged
(`epr_to_zpf`, `epr_numerical_diagonalization`, `QuantumAnalysis`). The
field-calculator token stack (`EnterQty` / `ClcMaterial` / `EnterVol` /
`EnterLine` / `Integrate`) and the eigenmode normalization
(`Solutions.EditSources`) are identical to the COM path and run fine over gRPC.

The single thing that does **not** survive gRPC is the stateful read-back
round-trip `ClcEval` + `GetTopEntryValue`. The backend reads results back with
`CalculatorWrite` (write to a `.fld` file, read the last line) instead — that is
the whole trick.

## Validation

Validated **digit-for-digit against the COM path** on a solved transmon
(headless, `non_graphical=True`):

| quantity | COM | PyAEDT (gRPC) |
|---|---|---|
| raw electric energy `U_E` | `4.198685e-23` | `4.198685e-23` |
| junction line voltage `V_peak` | `-2.200983e-05` | `-2.200983e-05` |
| **junction participation `p_mj`** | **`0.9755`** | **`0.9755`** |

## What's included

- `pyEPR/ansys_pyaedt.py` — `PyaedtDistributedAnalysis` + a pure-gRPC field
  calculator.
- `[pyaedt]` optional extra in `pyproject.toml` (`ansys-aedt-core`), imported
  lazily.
- **Tests** (`tests/test_ansys_pyaedt.py`): offline unit tests for the participation
  formula, unit parsing, `.aedt.lock` session targeting, and an
  "imports work without PyAEDT installed" test — all run in CI. Plus one
  `@pytest.mark.hfss` live test (skipped in CI; runs locally with AEDT).
- **CI**: a `test_pyaedt` job that installs the `[pyaedt]` extra and runs the
  backend's offline tests.
- **Docs**: a usage page (`docs/source/pyaedt_backend.rst`) and **Tutorial 7**.
- CHANGELOG entry and a short README note.

## No existing behavior changed

- No edits to `pyEPR.ansys` or any core analysis module.
- All existing tests pass; the new offline tests and the docs build are green.
- `import pyEPR` works with and without `ansys-aedt-core` installed (covered by a
  test).

## Note on packaging

I also have a more **surgical** variant on a separate branch
(`feature/pyaedt-ansys-grpc`) that teaches the existing `DistributedAnalysis` to
run over gRPC via `ProjectInfo(use_pyaedt=True)` instead of adding a parallel
module — smaller diff, but it edits core COM-facing code. Happy to switch to that
approach if you'd prefer it folded into `ansys.py`; I led with this additive
version since it touches no existing code.

## Testing done

- `pytest -m "not hfss"` — full suite passes (incl. the new offline tests).
- `pylint --errors-only pyEPR` — clean.
- `cd docs && make html` — builds with no new warnings.
- The `@pytest.mark.hfss` test and the full pipeline validated locally against a
  live AEDT 2026.1 session.
