### PR TITLE
bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [Unreleased]
+## [1.0.0] — 2026-06-27
 
 ### New features
 
 - **PyAEDT (gRPC) HFSS backend** (`pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis`).
+  Contributed by [Joey Yaker](https://github.com/joeyyaker).
   Runs the same Energy-Participation-Ratio field extraction as
   `DistributedAnalysis`, but through Ansys's official PyAEDT library
   (`pyaedt`) entirely over gRPC — no COM / `pywin32`. PyAEDT can attach

--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -90,7 +90,7 @@ __credits__ = [
     "Steven Touzard",
 ]
 __license__ = "BSD-3-Clause"
-__version__ = "0.9.6"
+__version__ = "1.0.0"
 __maintainer__ = "Zlatko K. Minev and  Asaf Diringer"
 __email__ = "zlatko.minev@aya.yale.edu"
 __url__ = r"https://github.com/zlatko-minev/pyEPR"

--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -59,8 +59,8 @@ Automated analysis of lumped and distributed circuits is provided.
 @author: Zlatko Minev, Zaki Leghas, ... and the pyEPR team
 @site: https://github.com/zlatko-minev/pyEPR
 @license: "BSD-3-Clause"
-@version: 0.9.5
-@maintainer: Zlatko K. Minev and  Asaf Diringer
+@version: 1.0.0
+@maintainer: Zlatko K. Minev, Joey Yaker, and the pyEPR team
 @email: zlatko.minev@aya.yale.edu
 @url: https://github.com/zlatko-minev/pyEPR
 @status: "Dev-Production"


### PR DESCRIPTION
## What's new in 1.0.0

First major release of pyEPR — marking a decade of use in quantum hardware labs and the first release with **cross-platform HFSS access**.

### New features

- **PyAEDT / gRPC backend** — `pyEPR.ansys_pyaedt.PyaedtDistributedAnalysis` runs the full EPR field extraction through Ansys's official PyAEDT API entirely over gRPC. No COM, no `pywin32`. Works on **Linux, macOS, and Windows**. Attaches to a running AEDT session via `.aedt.lock`, avoiding the stale-session and project-locked errors common with COM. Validated digit-for-digit against the COM path (`p_mj = 0.9755` on a demo transmon, `pyaedt 1.1.0` + AEDT 2026.1). Contributed by [Joey Yaker](https://github.com/joeyyaker).

  ```bash
  pip install "pyEPR-quantum[pyaedt]"
  ```

- **Tutorial 7** — end-to-end PyAEDT workflow notebook.
- **Docs** — new `pyaedt_backend` page, updated landing page and README featuring both backends.

### No breaking changes

All existing COM workflows, `DistributedAnalysis`, `QuantumAnalysis`, `ProjectInfo`, and the deprecated aliases (`pyEPR_HFSSAnalysis`, `pyEPR_Analysis`, `Project_Info`) are unchanged. The `[pyaedt]` extra is strictly optional — `import pyEPR` never requires it.

### Upgrading from 0.9.x

Drop-in. No call-site changes needed. Optionally install the gRPC backend:

```bash
pip install "pyEPR-quantum[pyaedt]"
```

---

**CI must be green before merging.** After merge, create a GitHub Release with tag `v1.0.0` to trigger PyPI publish via OIDC Trusted Publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011m5FF6jFLkLuZX2QEZh9m5)_