### PR TITLE
Release 1.0.1: variation-indexing bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [1.0.1] — 2026-07-14
+
+### Bug fixes
+
+- **Variation indexing (`DistributedAnalysis`)** — replaced the
+  `self._list_variations[ureg(variation)]` pattern with a new
+  `_variation_index()` helper. Passing `ureg()` (pint's unit registry) an
+  index label is incorrect: depending on the input type and installed pint
+  version, `ureg(variation)` could return a `pint.Quantity` instead of an
+  `int`, and indexing the `_list_variations` tuple with a `Quantity` raised
+  `TypeError: tuple indices must be integers or slices, not Quantity`. This
+  surfaced downstream as a crash in `plot_convergence()` / `get_convergence()`
+  (reported in qiskit-metal#1127). `_variation_index()` resolves an `int`, a
+  digit-string (`"0"`), or a full variation descriptor string
+  (`"Cj='2fF' Lj='12nH'"`) to a plain integer index without touching pint, and
+  raises a clear `ValueError` for an unknown label. Applied to all four call
+  sites (previously lines 370, 429, 1607, 1629) and removed the unguarded
+  `ureg(variation)` from the debug-log line that could raise
+  `UndefinedUnitError` on non-numeric labels.
+
 ## [1.0.0] — 2026-06-27
 
 ### New features

--- a/pyEPR/__init__.py
+++ b/pyEPR/__init__.py
@@ -59,7 +59,7 @@ Automated analysis of lumped and distributed circuits is provided.
 @author: Zlatko Minev, Zaki Leghas, ... and the pyEPR team
 @site: https://github.com/zlatko-minev/pyEPR
 @license: "BSD-3-Clause"
-@version: 1.0.0
+@version: 1.0.1
 @maintainer: Zlatko K. Minev, Joey Yaker, and the pyEPR team
 @email: zlatko.minev@aya.yale.edu
 @url: https://github.com/zlatko-minev/pyEPR
@@ -90,7 +90,7 @@ __credits__ = [
     "Steven Touzard",
 ]
 __license__ = "BSD-3-Clause"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __maintainer__ = "Zlatko K. Minev and  Asaf Diringer"
 __email__ = "zlatko.minev@aya.yale.edu"
 __url__ = r"https://github.com/zlatko-minev/pyEPR"


### PR DESCRIPTION
## Summary

Patch release so the already-merged variation-indexing fix (PRs #210 / #211) can ship to PyPI. The currently-released `1.0.0` still carries the `ureg(variation)` bug, because the fix landed on `master` *after* the `1.0.0` tag and `__version__` was never bumped.

- `pyEPR/__init__.py`: `__version__` and `@version` `1.0.0` → `1.0.1`
- `CHANGELOG.md`: new `[1.0.1]` entry describing the fix

No source-code changes — the `_variation_index()` fix is already on `master`.

## The bug this release ships the fix for

`DistributedAnalysis` resolved a variation label with `self._list_variations[ureg(variation)]`. `ureg` is pint's `UnitRegistry`; passing it an index label is semantically wrong and behaviourally unstable — depending on input type and pint version, `ureg(variation)` can return a `pint.Quantity` instead of an `int`, and indexing the `_list_variations` tuple with a `Quantity` raises:

```
TypeError: tuple indices must be integers or slices, not Quantity
```

This surfaced downstream as a crash in `plot_convergence()` / `get_convergence()`, reported in [qiskit-metal#1127](https://github.com/qiskit-community/qiskit-metal/issues/1127).

## Validation performed

- Reproduced the exact `TypeError` on the released `1.0.0` code (`ureg(0)` → `Quantity`, tuple-indexing raises).
- Confirmed `_variation_index()` on `master` resolves `int`, digit-string (`"0"`), and full descriptor string (`"Cj='2fF' Lj='12nH'"`) inputs correctly, and raises a clear `ValueError` on an unknown label.
- Full non-HFSS suite green: **233 passed, 8 deselected** (HFSS-marked).
- `pylint --errors-only pyEPR/core_distributed_analysis.py` clean.
- `import pyEPR` reports `1.0.1`.

## Release note

After merge, tag `v1.0.1` on `master` to trigger the PyPI publish (per the release workflow). quantum-metal's dependency floor is being raised to `pyEPR-quantum>=1.0.1` in a companion PR — release this first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_